### PR TITLE
Add firewall towards shoot in vpn-seed-server

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10.3
 RUN apk add --update bash curl openvpn bc && \
     rm -rf /var/cache/apk/*
 
-ADD seed-server/network-connection.sh seed-server/openvpn.config.template /
+ADD seed-server/network-connection.sh seed-server/openvpn.config.template seed-server/firewall.sh /
 
 RUN mkdir /client-config-dir
 ADD seed-server/vpn-shoot-client.template /client-config-dir

--- a/seed-server/firewall.sh
+++ b/seed-server/firewall.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cmd=$1
+
+if [ "$cmd" == "on" ]; then
+    iptables -A INPUT -m state --state RELATED,ESTABLISHED -i tun0 -j ACCEPT
+    iptables -A INPUT -i tun0 -j DROP
+elif [ "$cmd" == "off" ]; then
+    iptables -D INPUT -m state --state RELATED,ESTABLISHED -i tun0 -j ACCEPT
+    iptables -D INPUT -i tun0 -j DROP
+else
+    echo "usage: $0 [on|off]"
+fi

--- a/seed-server/openvpn.config.template
+++ b/seed-server/openvpn.config.template
@@ -27,6 +27,13 @@ cipher AES-256-CBC
 # manifest
 port 1194
 
+# Add firewall rules to block all traffic originating from the shoot cluster.
+# The scripts are run after the tun device has been created (up) or removed
+# (down).
+script-security 2
+up "/firewall.sh on"
+down "/firewall.sh off"
+
 keepalive 10 60
 server 192.168.123.0 255.255.255.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add firewall to `vpn-seed-server`.

**Which issue(s) this PR fixes**:
Fixes #1 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
This PR prevents any direct traffic from the shoot cluster towards the `vpn-seed-server` pod via the OpenVPN connection. Connectivity from the shoot cluster to the seed cluster via the VPN connection is not needed and blocked with this PR for security reasons.
```
