### PR TITLE
Added the option to passthrough a custom http header to the proxy server.

### DIFF
--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -62,6 +62,8 @@ pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
 node_network="${node_network:-}"
 
+reversed_vpn_header="${REVERSED_VPN_HEADER:-invalid-host}"
+
 # calculate netmask for given CIDR (required by openvpn)
 CIDR2Netmask() {
     local cidr="$1"
@@ -125,7 +127,7 @@ iptables --append POSTROUTING --out-interface eth0 --table nat -j MASQUERADE
 
 while : ; do
     if [[ ! -z $ENDPOINT ]]; then
-        openvpn --remote ${ENDPOINT} --port ${openvpn_port} --http-proxy ${ENDPOINT} ${openvpn_port} --config openvpn.config
+        openvpn --remote ${ENDPOINT} --port ${openvpn_port} --http-proxy ${ENDPOINT} ${openvpn_port} --http-proxy-option CUSTOM-HEADER Reversed-VPN "${reversed_vpn_header}" --config openvpn.config
     else
         log "No tunnel endpoint found"
     fi


### PR DESCRIPTION

**What this PR does / why we need it**:
It allows to pass a custom http header value with the name `Reversed-VPN` to the http proxy server.

**Which issue(s) this PR fixes**:
Partially addresses https://github.com/gardener/gardener/issues/4381.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator

```
