### PR TITLE
Filter out log output from readiness/liveness probes coming from local node.

### DIFF
--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -92,4 +92,7 @@ if [[ ! -z "$node_network" ]]; then
     done
 fi
 
-openvpn --config openvpn.config
+local_node_ip="${LOCAL_NODE_IP:-255.255.255.255}"
+
+# filter log output to remove readiness/liveness probes from local node
+openvpn --config openvpn.config | grep -v -E "TCP connection established with \[AF_INET\]${local_node_ip}|${local_node_ip}:[0-9]{1,5} Connection reset, restarting"


### PR DESCRIPTION
**What this PR does / why we need it**:
Filter out log output from readiness/liveness probes coming from local node.
The readiness/liveness probes can spam the log and make it hard to read while
providing no real value in the log output. Therefore, these are simply discarded.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Readiness/liveness probe log output is removed from log when local node ip is specified.
```
