### PR TITLE
Build arm64 based images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ vpn2:
         preprocess:
           'inject-commit-hash'
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           vpn-seed-server:
             inputs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Build and publish images for `amd64` and `arm64`.

**Which issue(s) this PR fixes**:
Fixes #8

**Special notes for your reviewer**:
/cc @ccwienk 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Container images are now being build and published also for `arm64` platforms.
```
