### PR TITLE
Allow running the vpn shoot client as unprivileged container.

### DIFF
--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -44,7 +44,16 @@ function configure_tcp() {
   set_value /proc/sys/net/ipv4/tcp_retries2 $tcp_retries2
 }
 
-configure_tcp
+if [[ -z "$DO_NOT_CONFIGURE_KERNEL_SETTINGS" ]]; then
+  configure_tcp
+
+  # make sure forwarding is enabled
+  echo 1 > /proc/sys/net/ipv4/ip_forward
+fi
+
+if [[ ! -z "$EXIT_AFTER_CONFIGURING_KERNEL_SETTINGS" ]]; then
+  exit
+fi
 
 # for each cidr config, it looks first at its env var, then a local file (which may be a volume mount), then the default
 baseConfigDir="/init-config"
@@ -117,9 +126,6 @@ echo "pull-filter ignore \"route\"" >> openvpn.config
 echo "pull-filter ignore redirect-gateway" >> openvpn.config
 echo "pull-filter ignore route-ipv6" >> openvpn.config
 echo "pull-filter ignore redirect-gateway-ipv6" >> openvpn.config
-
-# make sure forwarding is enabled
-echo 1 > /proc/sys/net/ipv4/ip_forward
 
 # enable forwarding and NAT
 iptables --append FORWARD --in-interface tun0 -j ACCEPT


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow running the vpn shoot client as unprivileged container.

The vpn shoot client sets certain kernel parameters, which require
privileged permissions. This change allows to run only the privileged
parts or only the unprivileged parts by specifying corresponding
environment variables.
Per default, the behaviour does not change.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
VPN shoot client can now be run with a privileged init container and a non-privileged runtime container
```
