### PR TITLE
Allow container to be run with CAP_NET_ADMIN only

### DIFF
--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -131,6 +131,11 @@ echo "pull-filter ignore redirect-gateway-ipv6" >> openvpn.config
 iptables --append FORWARD --in-interface tun0 -j ACCEPT
 iptables --append POSTROUTING --out-interface eth0 --table nat -j MASQUERADE
 
+if [[ ! -c /dev/net/tun ]]; then
+    mkdir -p /dev/net
+    mknod /dev/net/tun c 10 200
+fi
+
 while : ; do
     if [[ ! -z $ENDPOINT ]]; then
         openvpn --remote ${ENDPOINT} --port ${openvpn_port} --http-proxy ${ENDPOINT} ${openvpn_port} --http-proxy-option CUSTOM-HEADER Reversed-VPN "${reversed_vpn_header}" --config openvpn.config


### PR DESCRIPTION
**What this PR does / why we need it**:

This change removes the requirement to run vpn-shoot as a privileged container. The container must be run with capability CAP_NET_ADMIN.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/vpn/issues/41

**Special notes for your reviewer**:

This PR has not been tested so far. We have however proven the general feasibility in a sandbox setup (and tested the code snippet to work).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
This change removes the requirement to run vpn-shoot as a privileged container.
```
