### PR TITLE
Minimize container images to reduce attack surface.

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -12,15 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.15.4
+FROM alpine:3.15.4 as builder
 
-RUN apk add --update bash curl openvpn bc iptables && \
+RUN apk add --update bash openvpn bc iptables && \
     rm -rf /var/cache/apk/*
 
-ADD seed-server/network-connection.sh seed-server/openvpn.config.template seed-server/firewall.sh /
+WORKDIR /volume
 
-RUN mkdir /client-config-dir
-ADD seed-server/vpn-shoot-client.template /client-config-dir
+ADD seed-server/network-connection.sh seed-server/openvpn.config.template seed-server/firewall.sh ./
+
+RUN mkdir -p ./client-config-dir
+ADD seed-server/vpn-shoot-client.template ./client-config-dir
+
+RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables ./tmp ./run \
+    && cp -d /lib/ld-musl-* ./lib \
+    && cp -d /lib/libc.musl-* ./lib \
+    && cp -d /lib/libcrypto.so.* ./usr/lib \
+    && cp -d /lib/libssl.so.* ./usr/lib \
+    && cp -d /lib/libz.so.* ./lib \
+    && cp -d /usr/lib/libelf* ./usr/lib \
+    && cp -d /usr/lib/libip4* ./usr/lib \
+    && cp -d /usr/lib/libip6* ./usr/lib \
+    && cp -d /usr/lib/liblzo2.so.* ./usr/lib \
+    && cp -d /usr/lib/libmnl* ./usr/lib \
+    && cp -d /usr/lib/libncursesw.so.* ./usr/lib \
+    && cp -d /usr/lib/libnftnl* ./usr/lib \
+    && cp -d /usr/lib/libreadline.so.* ./usr/lib \
+    && cp -d /usr/lib/libxtables* ./usr/lib \
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables \
+    && cp -d /bin/bash ./bin \
+    && cp -d /bin/busybox ./bin \
+    && cp -d /bin/cat ./bin \
+    && cp -d /bin/date ./bin \
+    && cp -d /bin/echo ./bin \
+    && cp -d /bin/grep ./bin \
+    && cp -d /bin/sed ./bin \
+    && cp -d /bin/sh ./bin \
+    && cp -d /sbin/ip ./sbin \
+    && cp -d /sbin/iptables* ./sbin \
+    && cp -d /sbin/xtables* ./sbin \
+    && cp -d /usr/bin/bc ./usr/bin \
+    && cp -d /usr/bin/cut ./usr/bin \
+    && cp -d /usr/sbin/openvpn ./usr/sbin
+
+FROM scratch
+
+COPY --from=builder /volume /
 
 EXPOSE 1194
 

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -12,12 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.15.4
+FROM alpine:3.15.4 as builder
 
-RUN apk add --update bash curl openvpn iptables bc && \
+RUN apk add --update bash openvpn iptables bc && \
     rm -rf /var/cache/apk/*
 
-ADD shoot-client/network-connection.sh shoot-client/openvpn.config.template /
+WORKDIR /volume
+
+ADD shoot-client/network-connection.sh shoot-client/openvpn.config.template ./
+
+RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables ./tmp ./run \
+    && cp -d /lib/ld-musl-* ./lib \
+    && cp -d /lib/libc.musl-* ./lib \
+    && cp -d /lib/libcrypto.so.* ./usr/lib \
+    && cp -d /lib/libssl.so.* ./usr/lib \
+    && cp -d /lib/libz.so.* ./lib \
+    && cp -d /usr/lib/libelf* ./usr/lib \
+    && cp -d /usr/lib/libip4* ./usr/lib \
+    && cp -d /usr/lib/libip6* ./usr/lib \
+    && cp -d /usr/lib/liblzo2.so.* ./usr/lib \
+    && cp -d /usr/lib/libmnl* ./usr/lib \
+    && cp -d /usr/lib/libncursesw.so.* ./usr/lib \
+    && cp -d /usr/lib/libnftnl* ./usr/lib \
+    && cp -d /usr/lib/libreadline.so.* ./usr/lib \
+    && cp -d /usr/lib/libxtables* ./usr/lib \
+    && cp -d /usr/lib/xtables/* ./usr/lib/xtables \
+    && cp -d /bin/bash ./bin \
+    && cp -d /bin/busybox ./bin \
+    && cp -d /bin/cat ./bin \
+    && cp -d /bin/date ./bin \
+    && cp -d /bin/echo ./bin \
+    && cp -d /bin/sed ./bin \
+    && cp -d /bin/sh ./bin \
+    && cp -d /sbin/ip ./sbin \
+    && cp -d /sbin/iptables* ./sbin \
+    && cp -d /sbin/xtables* ./sbin \
+    && cp -d /usr/bin/bc ./usr/bin \
+    && cp -d /usr/bin/cut ./usr/bin \
+    && cp -d /usr/sbin/openvpn ./usr/sbin
+
+FROM scratch
+
+COPY --from=builder /volume /
 
 # We use "exec" and "trap 'exit' TERM" in the bash script, otherwise,
 # the script won't recieve and react to SIGTERM


### PR DESCRIPTION
**What this PR does / why we need it**:
Minimize container images to reduce attack surface.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
vpn-seed-server and vpn-shoot-client container images now contain only a reduced set of binary/libaries.
```
