### PR TITLE
Cleaned up openvpn warning/deprecation messages.

### DIFF
--- a/seed-server/openvpn.config.template
+++ b/seed-server/openvpn.config.template
@@ -16,11 +16,13 @@ mode server
 tls-server
 proto tcp4-server
 dev tun0
+topology subnet
 
 # Additonal optimizations
 txqueuelen 1000
 
 cipher AES-256-CBC
+data-ciphers AES-256-CBC
 
 # port can always be 1194 here as it is not visible externally. A different
 # port can be configured for the external load balancer in the service

--- a/shoot-client/openvpn.config.template
+++ b/shoot-client/openvpn.config.template
@@ -31,6 +31,7 @@ txqueuelen 1000
 pull
 
 cipher AES-256-CBC
+data-ciphers AES-256-CBC
 
 tls-client
 key "/srv/secrets/vpn-shoot/tls.key"
@@ -38,7 +39,6 @@ cert "/srv/secrets/vpn-shoot/tls.crt"
 ca "/srv/secrets/vpn-shoot/ca.crt"
 
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 1
-cipher AES-256-CBC
 
 # https://openvpn.net/index.php/open-source/documentation/howto.html#mitm
 remote-cert-tls server


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleaned up openvpn warning/deprecation messages.

Switched to topology subnet as recommended in
https://community.openvpn.net/openvpn/wiki/Topology. Furthermore,
specified data-ciphers in addition to cipher to ensure proper operation
even in case of openvpn updates. data-ciphers alone does not work as
expected and will yield other warnings.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Switched openvpn topology to subnet and ensured that the chosen cipher is always selected.
```
