### PR TITLE
Cleanup scheduler.alpha.kubernetes.io/critical-pod annotations

### DIFF
--- a/seed-server/example/seed-server-deployment.yaml
+++ b/seed-server/example/seed-server-deployment.yaml
@@ -25,11 +25,10 @@ spec:
       app: vpn-seed-server
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         app: vpn-seed-server
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       - effect: NoExecute
         operator: Exists

--- a/shoot-client/example/shoot-client-deployment.yaml
+++ b/shoot-client/example/shoot-client-deployment.yaml
@@ -25,11 +25,10 @@ spec:
       app: vpn-shoot-client
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         app: vpn-shoot-client
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       - effect: NoExecute
         operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup `scheduler.alpha.kubernetes.io/critical-pod` annotations

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubernetes/issues/79548

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
scheduler.alpha.kubernetes.io/critical-pod annotation is removed as pod priority (spec.priorityClassName) is used instead to mark pods as critical
```
