### PR TITLE
Restrict network ranges for HA VPN to `192.168.123.0/24`

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -44,12 +44,12 @@ func optionalGetEnvInt(name string, defaultValue, min, max int) int {
 func newIPAddressBrokerFromEnv() (ippool.IPAddressBroker, error) {
 	podName := mustGetEnv("POD_NAME")
 	namespace := mustGetEnv("NAMESPACE")
-	baseStr := optionalGetEnv("IP_BASE", "192.168.122.0")
+	baseStr := optionalGetEnv("IP_BASE", "192.168.123.0")
 	base := net.ParseIP(baseStr)
 	if base == nil || !strings.HasSuffix(baseStr, ".0") {
 		return nil, fmt.Errorf("invalid IP_BASE: %s", baseStr)
 	}
-	startIndex := optionalGetEnvInt("START_INDEX", 32, 32, 254)
+	startIndex := optionalGetEnvInt("START_INDEX", 200, 2, 254)
 	endIndex := optionalGetEnvInt("END_INDEX", 254, startIndex, 254)
 	labelSelector := optionalGetEnv("POD_LABEL_SELECTOR", "app=kubernetes,role=apiserver")
 	waitSeconds := optionalGetEnvInt("WAIT_SECONDS", 2, 1, 30)

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -17,6 +17,7 @@ FROM golang:1.19.3 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION
+COPY ./.git ./.git
 COPY ./go ./go
 ARG TARGETARCH
 RUN cd go; make build GOARCH=$TARGETARCH

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -21,11 +21,14 @@ function log() {
     echo "[$(date -u)]: $*"
 }
 
-bondPrefix="192.168.122"
+# cidr for bonding network: 192.168.123.192/26
+bondPrefix="192.168.123"
+bondBits="26"
+bondStart="192"
 
 for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
-  ip="${bondPrefix}.$((c+10))"
-  logline+="$((c+10))=\${ping_return[$ip]} "
+  ip="${bondPrefix}.$((bondStart+c+2))"
+  logline+="$((bondStart+c+2))=\${ping_return[$ip]} "
 done
 logline+=' using $new_ip'
 new_ip=""
@@ -42,7 +45,7 @@ declare -A ping_return
 function pingAllShootClients() {
     set +e
     for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
-        ip="${bondPrefix}.$((c+10))"
+        ip="${bondPrefix}.$((bondStart+c+2))"
         ping -W 2 -w 2 -c 1 $ip > /dev/null &
         ping_pid[$ip]=$!
     done
@@ -54,7 +57,7 @@ function pingAllShootClients() {
     fi
 
     for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
-        ip="${bondPrefix}.$((c+10))"
+        ip="${bondPrefix}.$((bondStart+c+2))"
         wait ${ping_pid[$ip]}
         ping_return[$ip]=$?
     done
@@ -64,7 +67,7 @@ function pingAllShootClients() {
 function selectNewShootClient() {
     local good=()
     for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
-        ip="${bondPrefix}.$((c+10))"
+        ip="${bondPrefix}.$((bondStart+c+2))"
         if [[ "${ping_return[$ip]}" == "0" ]]; then
             good+=($ip)
         fi


### PR DESCRIPTION
**What this PR does / why we need it**:
The network ranges used for HA VPN are condensed into `192.168.123.0/24` to avoid blocking additional ranges. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Restrict network ranges for HA VPN to `192.168.123.0/24`
```
