### PR TITLE
Set primary device for bond device

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -28,7 +28,8 @@ vpn2:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          retention_policy: 'clean-snapshots'
     pull-request:
       traits:
         pull-request: ~

--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.19.4 AS gobuilder
+FROM golang:1.19.5 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.19.4 AS gobuilder
+FROM golang:1.19.5 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -28,7 +28,7 @@ bondStart="192"
 
 for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
   ip="${bondPrefix}.$((bondStart+c+2))"
-  logline+="$((bondStart+c+2))=\${ping_return[$ip]} "
+  logline+="$((bondStart+c+2))=\${ping_return_msg[$ip]} "
 done
 logline+=' using $new_ip'
 new_ip=""
@@ -41,6 +41,7 @@ fi
 
 declare -A ping_pid
 declare -A ping_return
+declare -A ping_return_msg
 
 function pingAllShootClients() {
     set +e
@@ -60,6 +61,11 @@ function pingAllShootClients() {
         ip="${bondPrefix}.$((bondStart+c+2))"
         wait ${ping_pid[$ip]}
         ping_return[$ip]=$?
+        if [[ "${ping_return[$ip]}" == "0" ]]; then
+          ping_return_msg[$ip]="ok"
+        else
+          ping_return_msg[$ip]="err"
+        fi
     done
     set -e
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The primary slave device of the bond device is set to `tap0` (i.e. VPN connection via vpn-seed-server-0). The change is introduced to avoid situations where VPN clients are selecting different active slave for the bond device if multiple devices are up. This can lead to a kind of partitioning of the VPN clients with only the clients using the same slave devices can communicate via the bond device.

Additionally, minor changes are included:
- update builder image from `golang:1.19.4` to `golang:1.19.5`
- improve logging of path-controller (using `ok` and `err` instead of return code)
- cleanup of snapshots on head builds

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Set primary device for bond device to avoid partitioning of VPN clients into two groups
```

```improvement operator
Update builder image to `golang:1.19.5`
```
