### PR TITLE
bump builder image to golang:1.20.4

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.20.2 AS gobuilder
+FROM golang:1.20.4 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.20.2 AS gobuilder
+FROM golang:1.20.4 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:
bump builder image to golang:1.20.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Bump builder image golang from `1.20.2` to `1.20.4` 
```
