### PR TITLE
Bump builder image to golang:1.20.6

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.20.4 AS gobuilder
+FROM golang:1.20.6 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION

--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ############# gobuilder
-FROM golang:1.20.4 AS gobuilder
+FROM golang:1.20.6 AS gobuilder
 
 WORKDIR /build
 COPY ./VERSION ./VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump builder image golang from `1.20.4` to `1.20.6` 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Bump builder image golang from `1.20.4` to `1.20.6` 
```
