### PR TITLE
Security improvements

### DIFF
--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -126,7 +126,7 @@ client-config-dir /client-config-dir
 key "/srv/secrets/vpn-server/tls.key"
 cert "/srv/secrets/vpn-server/tls.crt"
 ca "/srv/secrets/vpn-server/ca.crt"
-dh "/srv/secrets/dh/dh2048.pem"
+dh none
 
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 EOF

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -128,6 +128,7 @@ cert "/srv/secrets/vpn-server/tls.crt"
 ca "/srv/secrets/vpn-server/ca.crt"
 dh none
 
+auth SHA256
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 EOF
 

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -111,8 +111,7 @@ topology subnet
 # Additonal optimizations
 txqueuelen 1000
 
-cipher AES-256-CBC
-data-ciphers AES-256-CBC
+data-ciphers AES-256-GCM:AES-128-GCM
 
 # port can always be 1194 here as it is not visible externally. A different
 # port can be configured for the external load balancer in the service

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -178,6 +178,7 @@ data-ciphers AES-256-GCM:AES-128-GCM
 
 tls-client
 
+auth SHA256
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 1
 
 # https://openvpn.net/index.php/open-source/documentation/howto.html#mitm

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -174,8 +174,7 @@ txqueuelen 1000
 # get all routing information from server
 pull
 
-cipher AES-256-CBC
-data-ciphers AES-256-CBC
+data-ciphers AES-256-GCM:AES-128-GCM
 
 tls-client
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces some security improvements to the openvpn configuration.
- `--cipher` is no longer set. This option should not be used any longer in TLS mode as stated in the `openvpn` docs.
- `--data-ciphers` now reflects the `openvpn` defaults and uses [Galois/Counter Mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode)
- `--dh` Diffie-Hellman key exchange is disabled in favour of elliptic curve Diffie-Hellman. ECDH parameters are handled automatically by openssl ([ref](https://github.com/OpenVPN/openvpn/blob/c827f9d83a7246971f435d0053b0252e49770f11/src/openvpn/ssl_openssl.c#L750))
- `--auth` is set to SHA256. Previously it was defaulted to SHA1.
 
 See more information on the official docs page https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/ and the following README document https://github.com/OpenVPN/openvpn/blob/master/README.ec
 
Logs from `vpn-shoot-client` before the changes (log verbosity increased by applying the configuration `verb 4`).

 <details>

```
2023-10-24 11:50:38 us=407216 Control Channel: TLSv1.3, cipher TLSv1.3 TLS_AES_256_GCM_SHA384, peer certificate: 3072 bit RSA, signature: RSA-SHA256
2023-10-24 11:50:38 us=407242 [vpn-seed-server] Peer Connection Initiated with [AF_INET]10.2.221.73:8132
2023-10-24 11:50:38 us=407279 TLS: move_session: dest=TM_ACTIVE src=TM_INITIAL reinit_src=1
2023-10-24 11:50:38 us=407356 TLS: tls_multi_process: initial untrusted session promoted to trusted
2023-10-24 11:50:38 us=448835 PUSH: Received control message: 'PUSH_REPLY,route-gateway 192.168.123.1,topology subnet,ping 10,ping-restart 60,ifconfig 192.168.123.10 255.255.255.0,peer-id 0,cipher AES-256-CBC,protocol-flags cc-exit tls-ekm dyn-tls-crypt,tun-mtu 1500'
2023-10-24 11:50:38 us=448888 OPTIONS IMPORT: --ifconfig/up options modified
2023-10-24 11:50:38 us=448901 OPTIONS IMPORT: route-related options modified
2023-10-24 11:50:38 us=448915 OPTIONS IMPORT: tun-mtu set to 1500
2023-10-24 11:50:38 us=449085 TUN/TAP device tun0 opened
2023-10-24 11:50:38 us=449117 TUN/TAP TX queue length set to 1000
2023-10-24 11:50:38 us=449142 do_ifconfig, ipv4=1, ipv6=0
2023-10-24 11:50:38 us=449162 /sbin/ip link set dev tun0 up mtu 1500
2023-10-24 11:50:38 us=450111 /sbin/ip link set dev tun0 up
2023-10-24 11:50:38 us=450761 /sbin/ip addr add dev tun0 192.168.123.10/24
2023-10-24 11:50:38 us=451486 Data Channel MTU parms [ mss_fix:1363 max_frag:0 tun_mtu:1500 tun_max_mtu:1600 headroom:136 payload:1768 tailroom:562 ET:0 ]
2023-10-24 11:50:38 us=451543 Outgoing dynamic tls-crypt: Cipher 'AES-256-CTR' initialized with 256 bit key
2023-10-24 11:50:38 us=451566 Outgoing dynamic tls-crypt: Using 256 bit message hash 'SHA256' for HMAC authentication
2023-10-24 11:50:38 us=451578 Incoming dynamic tls-crypt: Cipher 'AES-256-CTR' initialized with 256 bit key
2023-10-24 11:50:38 us=451595 Incoming dynamic tls-crypt: Using 256 bit message hash 'SHA256' for HMAC authentication
2023-10-24 11:50:38 us=451617 Outgoing Data Channel: Cipher 'AES-256-CBC' initialized with 256 bit key
2023-10-24 11:50:38 us=451634 Outgoing Data Channel: Using 160 bit message hash 'SHA1' for HMAC authentication
2023-10-24 11:50:38 us=451645 Incoming Data Channel: Cipher 'AES-256-CBC' initialized with 256 bit key
2023-10-24 11:50:38 us=451658 Incoming Data Channel: Using 160 bit message hash 'SHA1' for HMAC authentication
```

 </details>

Logs from `vpn-shoot-client` after the changes (log verbosity increased by applying the configuration `verb 4`).

 <details>

```
2023-10-24 11:53:28 us=454809 Control Channel: TLSv1.3, cipher TLSv1.3 TLS_AES_256_GCM_SHA384, peer certificate: 3072 bit RSA, signature: RSA-SHA256
2023-10-24 11:53:28 us=454836 [vpn-seed-server] Peer Connection Initiated with [AF_INET]10.2.221.73:8132
2023-10-24 11:53:28 us=454873 TLS: move_session: dest=TM_ACTIVE src=TM_INITIAL reinit_src=1
2023-10-24 11:53:28 us=454952 TLS: tls_multi_process: initial untrusted session promoted to trusted
2023-10-24 11:53:28 us=497657 PUSH: Received control message: 'PUSH_REPLY,route-gateway 192.168.123.1,topology subnet,ping 10,ping-restart 60,ifconfig 192.168.123.10 255.255.255.0,peer-id 0,cipher AES-256-GCM,protocol-flags cc-exit tls-ekm dyn-tls-crypt,tun-mtu 1500'
2023-10-24 11:53:28 us=497702 OPTIONS IMPORT: --ifconfig/up options modified
2023-10-24 11:53:28 us=497715 OPTIONS IMPORT: route-related options modified
2023-10-24 11:53:28 us=497739 OPTIONS IMPORT: tun-mtu set to 1500
2023-10-24 11:53:28 us=497925 TUN/TAP device tun0 opened
2023-10-24 11:53:28 us=497959 TUN/TAP TX queue length set to 1000
2023-10-24 11:53:28 us=497974 do_ifconfig, ipv4=1, ipv6=0
2023-10-24 11:53:28 us=497992 /sbin/ip link set dev tun0 up mtu 1500
2023-10-24 11:53:28 us=499033 /sbin/ip link set dev tun0 up
2023-10-24 11:53:28 us=499796 /sbin/ip addr add dev tun0 192.168.123.10/24
2023-10-24 11:53:28 us=500671 Data Channel MTU parms [ mss_fix:1386 max_frag:0 tun_mtu:1500 tun_max_mtu:1600 headroom:136 payload:1768 tailroom:562 ET:0 ]
2023-10-24 11:53:28 us=500724 Outgoing dynamic tls-crypt: Cipher 'AES-256-CTR' initialized with 256 bit key
2023-10-24 11:53:28 us=500742 Outgoing dynamic tls-crypt: Using 256 bit message hash 'SHA256' for HMAC authentication
2023-10-24 11:53:28 us=500758 Incoming dynamic tls-crypt: Cipher 'AES-256-CTR' initialized with 256 bit key
2023-10-24 11:53:28 us=500779 Incoming dynamic tls-crypt: Using 256 bit message hash 'SHA256' for HMAC authentication
2023-10-24 11:53:28 us=500802 Outgoing Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
2023-10-24 11:53:28 us=500817 Incoming Data Channel: Cipher 'AES-256-GCM' initialized with 256 bit key
2023-10-24 11:53:28 us=500829 Initialization Sequence Completed
2023-10-24 11:53:28 us=500839 Data Channel: cipher 'AES-256-GCM', peer-id
```

 </details>
 
 
 Mind that if we enforce TLS 1.2 by setting `tls-version-max 1.2` in the server config we can see that ECDH key exchange is enforced.
```
2023-10-24 11:55:34 us=337638 Control Channel: TLSv1.2, cipher TLSv1.2 ECDHE-RSA-AES256-GCM-SHA384, peer certificate: 3072 bit RSA, signature: RSA-SHA256
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Security improvements to the `openvpn` configuration.
```
