### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,6 +2,8 @@ vpn2:
   base_definition:
     traits:
       component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        component_name: github.com/gardener/vpn2
         component_labels:
         - name: 'cloud.gardener.cnudie/responsibles'
           value:
@@ -20,7 +22,7 @@ vpn2:
             inputs:
               repos:
                 source: ~ # default
-            image: 'eu.gcr.io/gardener-project/gardener/vpn-seed-server'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/vpn-seed-server
             dockerfile: 'seed-server/Dockerfile'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -32,7 +34,7 @@ vpn2:
                 integrity_requirement: 'high'
                 availability_requirement: 'high'
           vpn-shoot-client:
-            image: 'eu.gcr.io/gardener-project/gardener/vpn-shoot-client'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/vpn-shoot-client
             dockerfile: 'shoot-client/Dockerfile'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -43,10 +45,12 @@ vpn2:
                 confidentiality_requirement: 'low'
                 integrity_requirement: 'high'
                 availability_requirement: 'high'
-    steps: ~
   jobs:
     head-update:
       traits:
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -55,6 +59,18 @@ vpn2:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+          component_labels:
+          - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+            value:
+              policy: 'skip'
+        publish:
+          dockerimages:
+            vpn-seed-server:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-seed-server
+            vpn-shoot-client:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/vpn-shoot-client
         release:
           nextversion: 'bump_minor'
         slack:
@@ -63,9 +79,3 @@ vpn2:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          component_name: 'github.com/gardener/vpn2'
-          component_labels:
-          - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
-            value:
-              policy: 'skip'

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 vpn2:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       component_descriptor:
         component_labels:
@@ -22,7 +20,6 @@ vpn2:
             inputs:
               repos:
                 source: ~ # default
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/vpn-seed-server'
             dockerfile: 'seed-server/Dockerfile'
             resource_labels:
@@ -35,7 +32,6 @@ vpn2:
                 integrity_requirement: 'high'
                 availability_requirement: 'high'
           vpn-shoot-client:
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/vpn-shoot-client'
             dockerfile: 'shoot-client/Dockerfile'
             resource_labels:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 VERSION                       := $(shell cat VERSION)
-REGISTRY                      := eu.gcr.io/gardener-project/gardener
+REGISTRY                      := europe-docker.pkg.dev/gardener-project/public/gardener
 PREFIX                        := vpn
 SEED_SERVER_IMAGE_REPOSITORY  := $(REGISTRY)/$(PREFIX)-seed-server
 SEED_SERVER_IMAGE_TAG         := $(VERSION)

--- a/seed-server/example/seed-server-deployment.yaml
+++ b/seed-server/example/seed-server-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         operator: Exists
       containers:
       - name: vpn-seed-server
-        image: eu.gcr.io/gardener-project/gardener/vpn-seed-server:0.9.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/vpn-seed-server:0.9.0
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/shoot-client/example/shoot-client-deployment.yaml
+++ b/shoot-client/example/shoot-client-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         operator: Exists
       containers:
       - name: vpn-shoot-client
-        image: eu.gcr.io/gardener-project/gardener/vpn-shoot-client:0.9.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/vpn-shoot-client:0.9.0
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
