### PR TITLE
Add iptables backend detection to firewall script.

### DIFF
--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -25,7 +25,7 @@ RUN cd go; make build-openvpn-exporter GOARCH=$TARGETARCH
 ############# builder
 FROM alpine:3.19.0 as builder
 
-RUN apk add --update bash openvpn iptables-legacy ncurses-libs bc ip6tables && \
+RUN apk add --update bash openvpn iptables iptables-legacy ncurses-libs bc && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume

--- a/seed-server/Dockerfile
+++ b/seed-server/Dockerfile
@@ -25,7 +25,7 @@ RUN cd go; make build-openvpn-exporter GOARCH=$TARGETARCH
 ############# builder
 FROM alpine:3.19.0 as builder
 
-RUN apk add --update bash openvpn iptables ncurses-libs bc ip6tables && \
+RUN apk add --update bash openvpn iptables-legacy ncurses-libs bc ip6tables && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -86,6 +86,8 @@ RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables
     && cp -d /sbin/iptables* ./sbin                                         && echo "package iptables" \
     && cp -d /sbin/xtables* ./sbin                                          && echo "package iptables" \
     && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
+    && cp -d /usr/lib/libip4* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
     && cp -d /sbin/ip6tables* ./sbin                                        && echo "package ip6tables"
 

--- a/seed-server/firewall.sh
+++ b/seed-server/firewall.sh
@@ -3,16 +3,27 @@
 cmd=$1
 dev=$2
 
+if iptables-legacy -L >/dev/null && ip6tables-legacy -L >/dev/null ; then
+  echo "using iptables backend legacy" 
+  backend="-legacy"
+elif iptables-nft -L >/dev/null && ip6tables-nft -L >/dev/null ; then
+  echo "using iptables backend nft" 
+  backend="-nft"
+else
+  echo "iptables seems not to be supported."
+  exit 1
+fi
+
 iptables() {
   # execute all commands for IPv4 and IPv6
-  command iptables "$@"
-  command ip6tables "$@"
+  command iptables$backend "$@"
+  command ip6tables$backend "$@"
 }
 
-if [ "$cmd" == "on" ]; then
+if [ "$cmd" = "on" ]; then
     iptables -A INPUT -m state --state RELATED,ESTABLISHED -i $dev -j ACCEPT
     iptables -A INPUT -i $dev -j DROP
-elif [ "$cmd" == "off" ]; then
+elif [ "$cmd" = "off" ]; then
     iptables -D INPUT -m state --state RELATED,ESTABLISHED -i $dev -j ACCEPT
     iptables -D INPUT -i $dev -j DROP
 else


### PR DESCRIPTION
**What this PR does / why we need it**:
On some os versions not all required modules are present in the vpn-seed-server container. 
This PR adds a simple check to the firewall script to find the working iptables version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Add iptables backend detection to firewall script.
```
