### PR TITLE
Make VPN Network configurable

### DIFF
--- a/seed-server/example/seed-server-deployment.yaml
+++ b/seed-server/example/seed-server-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           value: # pod network, e.g. 100.96.0.0/16
         - name: NODE_NETWORK
           value: # node network, e.g. 10.250.0.0/16
+        - name: VPN_NETWORK
+          value: # VPN network, e.g. 192.168.123.0/24
       volumes:
       - name: vpn-secrets
         secret:

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -42,8 +42,8 @@ pod_network="${POD_NETWORK:-${filePodNetwork}}"
 pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
 node_network="${node_network:-}"
+# defaults for vpn_network are set depending on IP_FAMILIES below
 vpn_network="${VPN_NETWORK:-${fileVPNNetwork}}"
-vpn_network="${vpn_network:-192.168.123.0/24}"
 
 is_ha=
 if [[ $POD_NAME =~ .*-([0-2])$ ]]; then
@@ -58,14 +58,19 @@ if [[ "$IP_FAMILIES" = "IPv6" ]]; then
     log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
     exit 1
   else
+    # set IPv6 default if no config has been provided
+    vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
     openvpn_network=${vpn_network}
   fi
 else
+  # set IPv4 default if no config has been provided
+  vpn_network="${vpn_network:-"192.168.123.0/24"}"
+  
   if [[ $vpn_network != */24 ]]; then
     log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
     exit 1
   fi
-
+  
   # it's guaranteed that the VPN network range is a /24 net,
   # so it's safe to just cut off after the first three octets
   IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"

--- a/shoot-client/example/shoot-client-deployment.yaml
+++ b/shoot-client/example/shoot-client-deployment.yaml
@@ -48,12 +48,14 @@ spec:
         - name: vpn-secrets
           mountPath: /srv/secrets
         env:
-        - name:  SERVICE_NETWORK
+        - name: SERVICE_NETWORK
           value: # service network, e.g. 100.68.0.0/14
         - name: POD_NETWORK
           value: # pod network, e.g. 100.96.0.0/16
         - name: NODE_NETWORK
           value: # node network, e.g. 10.250.0.0/16
+        - name: VPN_NETWORK
+          value: # VPN network, e.g. 192.168.123.0/24
         - name: ENDPOINT
           value: # open vpn endpoint
         - name: OPENVPN_PORT

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -29,10 +29,26 @@ if [[ "$IP_FAMILIES" = "IPv6" ]]; then
   iptables=ip6tables
 fi
 
-# cidr for bonding network: 192.168.123.192/26
-bondPrefix="192.168.123"
+vpn_network="${VPN_NETWORK:-192.168.123.0/24}"
+bondPrefix=
 bondBits="26"
 bondStart="192"
+
+if [[ $IP_FAMILIES == "IPv4" ]]; then
+  if [[ $vpn_network != */24 ]]; then
+    log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
+    exit 1
+  fi
+
+  # it's guaranteed that the VPN network range is a /24 net,
+  # so it's safe to just cut off after the first three octets
+  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
+  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+
+  # cidr for bonding network: last /26 subnet of the /24 VPN network range
+  bondPrefix=${first_three_octets_of_ipv4_vpn}
+fi
+
 
 tcp_keepalive_time="${TCP_KEEPALIVE_TIME:-7200}"
 tcp_keepalive_intvl="${TCP_KEEPALIVE_INTVL:-75}"

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -21,10 +21,25 @@ function log() {
     echo "[$(date -u)]: $*"
 }
 
-# cidr for bonding network: 192.168.123.192/26
-bondPrefix="192.168.123"
+vpn_network="${VPN_NETWORK:-192.168.123.0/24}"
+bondPrefix=
 bondBits="26"
 bondStart="192"
+
+if [[ $IP_FAMILIES == "IPv4" ]]; then
+  if [[ $vpn_network != */24 ]]; then
+    log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
+    exit 1
+  fi
+
+  # it's guaranteed that the VPN network range is a /24 net,
+  # so it's safe to just cut off after the first three octets
+  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
+  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+
+  # cidr for bonding network: last /26 subnet of the /24 VPN network range
+  bondPrefix=${first_three_octets_of_ipv4_vpn}
+fi
 
 for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
   ip="${bondPrefix}.$((bondStart+c+2))"


### PR DESCRIPTION
**What this PR does / why we need it**:

In gardener/gardener#8987 we proposed to make the VPN network range configurable. Regardless of how exactly this feature is implemented on the Gardener side (e.g. per Shoot or per Seed), the requirements for the `vpn2` components stay the same: They need to be able to handle an additional environment variable called `VPN_NETWORK` and produce a correct VPN config from its value.

This PR introduces some changes to both the `seed-server` and the `shoot-client` components to fulfill these requirements.

**Which issue(s) this PR fixes**:

Part of gardener/gardener#8987

**Special notes for your reviewer**:

* When the `VPN_NETWORK` environment variable is not set, the implementation should behave exactly the same as before, ensuring backwards-compatibility.
* A previously implicit requirement (`IPv4` networks always have a size of `/24`) is now explicitly tested, and the script fails if the network has a different size.
* I don't know how or where the `shoot-client/path-controller.sh` is used, but assumed that it needs to be adapted just as the `network-connection.sh` scripts.
* From my understanding, the `go` parts of `vpn2` don't need to be altered for this change. Please advise if I missed something there.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
The VPN components now support configuring a custom VPN network using the VPN_NETWORK environment variable.
```
