### PR TITLE
Add iptables backend detection to vpn shoot client.

### DIFF
--- a/shoot-client/Dockerfile
+++ b/shoot-client/Dockerfile
@@ -25,7 +25,7 @@ RUN cd go; make build-acquire-ip GOARCH=$TARGETARCH
 ############# builder
 FROM alpine:3.19.0 as builder
 
-RUN apk add --update bash openvpn iptables ip6tables ncurses-libs bc && \
+RUN apk add --update bash openvpn iptables iptables-legacy ncurses-libs bc && \
     rm -rf /var/cache/apk/*
 
 WORKDIR /volume
@@ -87,6 +87,8 @@ RUN mkdir -p ./bin ./sbin ./lib ./usr/bin ./usr/sbin ./usr/lib ./usr/lib/xtables
     && cp -d /sbin/iptables* ./sbin                                         && echo "package iptables" \
     && cp -d /sbin/xtables* ./sbin                                          && echo "package iptables" \
     && cp -d /usr/lib/libxtables* ./usr/lib                                 && echo "package iptables" \
+    && cp -d /usr/lib/libip4* ./usr/lib                                     && echo "package iptables" \
+    && cp -d /usr/lib/libip6* ./usr/lib                                     && echo "package iptables" \
     && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo "package iptables" \
     && cp -d /sbin/ip6tables* ./sbin                                        && echo "package ip6tables"
 

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -24,9 +24,20 @@ trap 'exit' TERM SIGINT
 IP_FAMILIES="${IP_FAMILIES:-IPv4}"
 openvpn_port="${OPENVPN_PORT:-8132}"
 
-iptables=iptables
+if iptables-legacy -L >/dev/null && ip6tables-legacy -L >/dev/null ; then
+  echo "using iptables backend legacy" 
+  backend="-legacy"
+elif iptables-nft -L >/dev/null && ip6tables-nft -L >/dev/null ; then
+  echo "using iptables backend nft" 
+  backend="-nft"
+else
+  echo "iptables seems not to be supported."
+  exit 1
+fi
+
+iptables=iptables-$backend
 if [[ "$IP_FAMILIES" = "IPv6" ]]; then
-  iptables=ip6tables
+  iptables=ip6tables-$backend
 fi
 
 # cidr for bonding network: 192.168.123.192/26

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -35,9 +35,9 @@ else
   exit 1
 fi
 
-iptables=iptables-$backend
+iptables=iptables$backend
 if [[ "$IP_FAMILIES" = "IPv6" ]]; then
-  iptables=ip6tables-$backend
+  iptables=ip6tables$backend
 fi
 
 # cidr for bonding network: 192.168.123.192/26


### PR DESCRIPTION
**What this PR does / why we need it**:
On some os versions not all required modules are present in the  container.
This PR adds a simple check to the firewall script to find the working iptables version for the shoot-client.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Add iptables backend detection to shoot-client.
```
