### PR TITLE
Make VPN Network configurable

### DIFF
--- a/seed-server/example/seed-server-deployment.yaml
+++ b/seed-server/example/seed-server-deployment.yaml
@@ -38,12 +38,14 @@ spec:
         - name: vpn-secrets
           mountPath: /srv/secrets
         env:
-        - name:  SERVICE_NETWORK
+        - name: SERVICE_NETWORK
           value: # service network, e.g. 100.68.0.0/14
         - name: POD_NETWORK
           value: # pod network, e.g. 100.96.0.0/16
         - name: NODE_NETWORK
           value: # node network, e.g. 10.250.0.0/16
+        - name: VPN_NETWORK
+          value: # VPN network, e.g. 192.168.123.0/24
       volumes:
       - name: vpn-secrets
         secret:

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -32,8 +32,8 @@ pod_network="${POD_NETWORK:-${filePodNetwork}}"
 pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
 node_network="${node_network:-}"
+# defaults for vpn_network are set depending on IP_FAMILIES below
 vpn_network="${VPN_NETWORK:-${fileVPNNetwork}}"
-vpn_network="${vpn_network:-192.168.123.0/24}"
 
 is_ha=
 if [[ $POD_NAME =~ .*-([0-2])$ ]]; then
@@ -48,14 +48,19 @@ if [[ "$IP_FAMILIES" = "IPv6" ]]; then
     log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
     exit 1
   else
+    # set IPv6 default if no config has been provided
+    vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
     openvpn_network=${vpn_network}
   fi
 else
+  # set IPv4 default if no config has been provided
+  vpn_network="${vpn_network:-"192.168.123.0/24"}"
+  
   if [[ $vpn_network != */24 ]]; then
     log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
     exit 1
   fi
-
+  
   # it's guaranteed that the VPN network range is a /24 net,
   # so it's safe to just cut off after the first three octets
   IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -71,13 +71,19 @@ if [[ "$IP_FAMILIES" = "IPv4" ]]; then
     pool_end_ip="${first_three_octets_of_ipv4_vpn}.254"
   fi
 else
+  # set IPv6 default if no config has been provided
+  vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
+
+  if [[ $vpn_network != */120 ]]; then
+    log "error: the IPv6 VPN setup requires the VPN network range to have a /120 suffix"
+    exit 1
+  fi
+
   if [[ -n $is_ha ]]; then
     log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
     exit 1
   fi
 
-  # set IPv6 default if no config has been provided
-  vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
   openvpn_network=${vpn_network}
 fi
 

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -15,44 +15,16 @@ IP_FAMILIES="${IP_FAMILIES:-IPv4}"
 
 # for each cidr config, it looks first at its env var, then a local file (which may be a volume mount), then the default
 baseConfigDir="/init-config"
+
 fileServiceNetwork=
 filePodNetwork=
 fileNodeNetwork=
+fileVPNNetwork=
+
 [ -e "${baseConfigDir}/serviceNetwork" ] && fileServiceNetwork=$(cat ${baseConfigDir}/serviceNetwork)
 [ -e "${baseConfigDir}/podNetwork" ] && filePodNetwork=$(cat ${baseConfigDir}/podNetwork)
 [ -e "${baseConfigDir}/nodeNetwork" ] && fileNodeNetwork=$(cat ${baseConfigDir}/nodeNetwork)
-
-is_ha=
-if [[ $POD_NAME =~ .*-([0-2])$ ]]; then
-  is_ha=true
-  vpn_index=${BASH_REMATCH[1]}
-fi
-
-if [[ -n $is_ha ]]; then
-  if [[ "$IP_FAMILIES" != "IPv4" ]]; then
-    log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
-    exit 1
-  fi
-
-  # HA VPN tunnels split the 192.168.123.0/24 into four ranges:
-  # vpn-server-0: 192.168.123.0/26
-  # vpn-server-1: 192.168.123.64/26
-  # vpn-server-2: 192.168.123.128/26 (optional)
-  # bonding:      192.168.123.192/26
-  openvpn_network="192.168.123.$((vpn_index * 64))/26"
-  pool_start_ip="192.168.123.$((vpn_index * 64 + 8))"
-  pool_end_ip="192.168.123.$((vpn_index * 64 + 62))"
-else
-  if [[ "$IP_FAMILIES" = "IPv4" ]]; then
-    openvpn_network="192.168.123.0/24"
-    pool_start_ip="192.168.123.10"
-    pool_end_ip="192.168.123.254"
-  else
-    openvpn_network="fd8f:6d53:b97a:1::/120"
-  fi
-fi
-
-log "using openvpn_network=$openvpn_network"
+[ -e "${baseConfigDir}/vpnNetwork" ] && fileVPNNetwork=$(cat ${baseConfigDir}/vpnNetwork)
 
 service_network="${SERVICE_NETWORK:-${fileServiceNetwork}}"
 service_network="${service_network:-100.64.0.0/13}"
@@ -60,6 +32,52 @@ pod_network="${POD_NETWORK:-${filePodNetwork}}"
 pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
 node_network="${node_network:-}"
+vpn_network="${VPN_NETWORK:-${fileVPNNetwork}}"
+vpn_network="${vpn_network:-192.168.123.0/24}"
+
+is_ha=
+if [[ $POD_NAME =~ .*-([0-2])$ ]]; then
+  is_ha=true
+  vpn_index=${BASH_REMATCH[1]}
+fi
+
+first_three_octets_of_ipv4_vpn=
+
+if [[ "$IP_FAMILIES" = "IPv6" ]]; then
+  if [[ -n $is_ha ]]; then
+    log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
+    exit 1
+  else
+    openvpn_network=${vpn_network}
+  fi
+else
+  if [[ $vpn_network != */24 ]]; then
+    log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
+    exit 1
+  fi
+
+  # it's guaranteed that the VPN network range is a /24 net,
+  # so it's safe to just cut off after the first three octets
+  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
+  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+
+  if [[ -n $is_ha ]]; then
+    # HA VPN tunnels split the /24 VPN network into four /26 ranges:
+    # vpn-server-0: first /26
+    # vpn-server-1: second /26
+    # vpn-server-2: third /26 (optional)
+    # bonding:      fourth /26
+    openvpn_network="${first_three_octets_of_ipv4_vpn}.$((vpn_index * 64))/26"
+    pool_start_ip="${first_three_octets_of_ipv4_vpn}.$((vpn_index * 64 + 8))"
+    pool_end_ip="${first_three_octets_of_ipv4_vpn}.$((vpn_index * 64 + 62))"
+  else
+    openvpn_network=${vpn_network}
+    pool_start_ip="${first_three_octets_of_ipv4_vpn}.10"
+    pool_end_ip="${first_three_octets_of_ipv4_vpn}.254"
+  fi
+fi
+
+log "using openvpn_network=$openvpn_network"
 
 # calculate netmask for given CIDR (required by openvpn)
 #
@@ -152,7 +170,7 @@ if [[ -n $is_ha ]]; then
   echo "duplicate-cn" >>openvpn.config
 
   for ((i = 0; i < $HA_VPN_CLIENTS; i++)); do
-    printf 'ifconfig-push %s %s\n' "192.168.123.$((vpn_index * 64 + i + 2))" "$(CIDR2Netmask $openvpn_network)" >/client-config-dir/vpn-shoot-client-$i
+    printf 'ifconfig-push %s %s\n' "${first_three_octets_of_ipv4_vpn}.$((vpn_index * 64 + i + 2))" "$(CIDR2Netmask $openvpn_network)" >/client-config-dir/vpn-shoot-client-$i
   done
 else
   dev="tun0"

--- a/seed-server/network-connection.sh
+++ b/seed-server/network-connection.sh
@@ -43,28 +43,18 @@ fi
 
 first_three_octets_of_ipv4_vpn=
 
-if [[ "$IP_FAMILIES" = "IPv6" ]]; then
-  if [[ -n $is_ha ]]; then
-    log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
-    exit 1
-  else
-    # set IPv6 default if no config has been provided
-    vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
-    openvpn_network=${vpn_network}
-  fi
-else
+if [[ "$IP_FAMILIES" = "IPv4" ]]; then
   # set IPv4 default if no config has been provided
   vpn_network="${vpn_network:-"192.168.123.0/24"}"
-  
+
   if [[ $vpn_network != */24 ]]; then
     log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
     exit 1
   fi
-  
+
   # it's guaranteed that the VPN network range is a /24 net,
-  # so it's safe to just cut off after the first three octets
-  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
-  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+  # so it's safe to just cut off the last octet and net size
+  first_three_octets_of_ipv4_vpn=${vpn_network%.*}
 
   if [[ -n $is_ha ]]; then
     # HA VPN tunnels split the /24 VPN network into four /26 ranges:
@@ -80,6 +70,15 @@ else
     pool_start_ip="${first_three_octets_of_ipv4_vpn}.10"
     pool_end_ip="${first_three_octets_of_ipv4_vpn}.254"
   fi
+else
+  if [[ -n $is_ha ]]; then
+    log "error: the highly-available VPN setup is only supported for IPv4 single-stack shoots"
+    exit 1
+  fi
+
+  # set IPv6 default if no config has been provided
+  vpn_network="${vpn_network:-"fd8f:6d53:b97a:1::/120"}"
+  openvpn_network=${vpn_network}
 fi
 
 log "using openvpn_network=$openvpn_network"

--- a/shoot-client/example/shoot-client-deployment.yaml
+++ b/shoot-client/example/shoot-client-deployment.yaml
@@ -38,12 +38,14 @@ spec:
         - name: vpn-secrets
           mountPath: /srv/secrets
         env:
-        - name:  SERVICE_NETWORK
+        - name: SERVICE_NETWORK
           value: # service network, e.g. 100.68.0.0/14
         - name: POD_NETWORK
           value: # pod network, e.g. 100.96.0.0/16
         - name: NODE_NETWORK
           value: # node network, e.g. 10.250.0.0/16
+        - name: VPN_NETWORK
+          value: # VPN network, e.g. 192.168.123.0/24
         - name: ENDPOINT
           value: # open vpn endpoint
         - name: OPENVPN_PORT

--- a/shoot-client/network-connection.sh
+++ b/shoot-client/network-connection.sh
@@ -30,10 +30,26 @@ if [[ "$IP_FAMILIES" = "IPv6" ]]; then
   iptables=ip6tables$backend
 fi
 
-# cidr for bonding network: 192.168.123.192/26
-bondPrefix="192.168.123"
+vpn_network="${VPN_NETWORK:-192.168.123.0/24}"
+bondPrefix=
 bondBits="26"
 bondStart="192"
+
+if [[ $IP_FAMILIES == "IPv4" ]]; then
+  if [[ $vpn_network != */24 ]]; then
+    log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
+    exit 1
+  fi
+
+  # it's guaranteed that the VPN network range is a /24 net,
+  # so it's safe to just cut off after the first three octets
+  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
+  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+
+  # cidr for bonding network: last /26 subnet of the /24 VPN network range
+  bondPrefix=${first_three_octets_of_ipv4_vpn}
+fi
+
 
 tcp_keepalive_time="${TCP_KEEPALIVE_TIME:-7200}"
 tcp_keepalive_intvl="${TCP_KEEPALIVE_INTVL:-75}"

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -11,24 +11,39 @@ function log() {
     echo "[$(date -u)]: $*"
 }
 
-vpn_network="${VPN_NETWORK:-192.168.123.0/24}"
+# apply env var defaults
+IP_FAMILIES="${IP_FAMILIES:-IPv4}"
+
 bondPrefix=
 bondBits="26"
 bondStart="192"
 
 if [[ $IP_FAMILIES == "IPv4" ]]; then
+  # set IPv4 default if no config has been provided
+  vpn_network="${VPN_NETWORK:-"192.168.123.0/24"}"
+
   if [[ $vpn_network != */24 ]]; then
     log "error: the IPv4 VPN setup requires the VPN network range to have a /24 suffix"
     exit 1
   fi
 
   # it's guaranteed that the VPN network range is a /24 net,
-  # so it's safe to just cut off after the first three octets
-  IFS=./ read -r octet1 octet2 octet3 octet4 suffix <<< "${vpn_network}"
-  first_three_octets_of_ipv4_vpn=$(printf '%s.%s.%s' "$octet1" "$octet2" "$octet3")
+  # so it's safe to just cut off the last octet and net size
+  first_three_octets_of_ipv4_vpn=${vpn_network%.*}
 
   # cidr for bonding network: last /26 subnet of the /24 VPN network range
   bondPrefix=${first_three_octets_of_ipv4_vpn}
+else
+  # set IPv6 default if no config has been provided
+  vpn_network="${VPN_NETWORK:-"fd8f:6d53:b97a:1::/120"}"
+
+  if [[ $vpn_network != */120 ]]; then
+    log "error: the IPv6 VPN setup requires the VPN network range to have a /120 suffix"
+    exit 1
+  fi
+
+  # the highly-available VPN setup is only supported for IPv4 single-stack shoots
+  # hence, the bonding-related calculations are not performed here
 fi
 
 for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the `VPN_NETWORK` env var in both seed-server and shoot-client that allows configuring a custom VPN CIDR.
If unset, it defaults to the current hard-coded values (`192.168.123.0/24` and `fd8f:6d53:b97a:1::/120` respectively).

This PR introduces some changes to both the seed-server and the shoot-client components to fulfill these requirements.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/8987

**Special notes for your reviewer**:

The PR builds upon https://github.com/gardener/vpn2/pull/64. It rebases the existing commits and adds a few more commits to address the remaining issues.

TODOs:

- [ ] verify this change without configuring `VPN_NETWORK` (backward-compatibility): must result in the same VPN configs, IP addresses, and routes
  - [ ] IPv4 non-HA
  - [ ] IPv4 HA
  - [ ] IPv6
- [ ] verify this change with a non-default `VPN_NETWORK` together with https://github.com/gardener/gardener/pull/8991

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```feature operator
The VPN components now support configuring a custom VPN network using the `VPN_NETWORK` environment variable.
```
```breaking operator
The `IP_BASE` environment variable in `acquire-ip` (part of `vpn-shoot-client`) is dropped in favor of the `VPN_NETWORK` environment variable.
```
