### PR TITLE
Use IPv6 VPN transfernetwork

### DIFF
--- a/IPv6-transfernet.md
+++ b/IPv6-transfernet.md
@@ -1,0 +1,7 @@
+# Using a IPv6 transfer vpn network for VPN2 instead of 192.168.123.0/24
+
+- [] routes created on vpn-seed-server
+- [] rp_filter disabled on eth0 (all?) on vpn-shoot-client, not required if backroute is added
+- [] proto tcp4 server|client
+- [] IP_FAMILIES set to IPv6
+- [] back route created on vpn-shoot-client

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ docker-login:
 docker-push:
 	@if ! docker images $(SEED_SERVER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(SEED_SERVER_IMAGE_TAG); then echo "$(SEED_SERVER_IMAGE_REPOSITORY) version $(SEED_SERVER_IMAGE_TAG) is not yet built. Please run 'make seed-server-docker-image'"; false; fi
 	@if ! docker images $(SHOOT_CLIENT_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(SHOOT_CLIENT_IMAGE_TAG); then echo "$(SHOOT_CLIENT_IMAGE_REPOSITORY) version $(SHOOT_CLIENT_IMAGE_TAG) is not yet built. Please run 'make shoot-client-docker-image'"; false; fi
-	@gcloud docker -- push $(SEED_SERVER_IMAGE_REPOSITORY):$(SEED_SERVER_IMAGE_TAG)
-	@gcloud docker -- push $(SHOOT_CLIENT_IMAGE_REPOSITORY):$(SHOOT_CLIENT_IMAGE_TAG)
+	@docker push $(SEED_SERVER_IMAGE_REPOSITORY):$(SEED_SERVER_IMAGE_TAG)
+	@docker push $(SHOOT_CLIENT_IMAGE_REPOSITORY):$(SHOOT_CLIENT_IMAGE_TAG)

--- a/seed-server/firewall.sh
+++ b/seed-server/firewall.sh
@@ -2,6 +2,8 @@
 
 cmd=$1
 dev=$2
+service_network=$3
+pod_network=$4
 
 if iptables-legacy -L >/dev/null && ip6tables-legacy -L >/dev/null ; then
   echo "using iptables backend legacy" 
@@ -23,6 +25,9 @@ iptables() {
 if [ "$cmd" = "on" ]; then
     iptables -A INPUT -m state --state RELATED,ESTABLISHED -i $dev -j ACCEPT
     iptables -A INPUT -i $dev -j DROP
+    ip route add ${service_network} dev $dev
+    ip route add ${pod_network} dev $dev
+    # FIXME add NODE_NETWORK
 elif [ "$cmd" = "off" ]; then
     iptables -D INPUT -m state --state RELATED,ESTABLISHED -i $dev -j ACCEPT
     iptables -D INPUT -i $dev -j DROP


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace the existing 192.168.123.0/24 network which is currently in use for the vpn transfernetwork with a IPv6 ULA address space. This frees the usable networks ranges for shoots.

**Which issue(s) this PR fixes**:
Fixes # 

Is a simpler approach than what @timebertt did in https://github.com/gardener/gardener/pull/9597

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator

```
