### PR TITLE
Print ping messages taking more than 100 ms

### DIFF
--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -74,7 +74,7 @@ function pingAllShootClients() {
         # --- 192.168.123.194 ping statistics ---
         # 1 packets transmitted, 1 packets received, 0% packet loss
         # round-trip min/avg/max = 13.658/13.658/13.658 ms
-        ping -W 2 -w 2 -c 1 $ip | sed '/\(^PING.*\|^---.*---$\|.*1 packets received.*\|^round-trip.*\|^$\|.*time=...... ms$\)/d' &
+        ping -W 2 -w 2 -c 1 $ip | sed '/\(^PING.*\|^---.*---$\|.*1 packets received.*\|^round-trip.*\|^$\|.*time=.\?..... ms$\)/d' &
         ping_pid[$ip]=$!
     done
 

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -67,14 +67,7 @@ function pingAllShootClients() {
     set +e
     for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
         ip="${bondPrefix}.$((bondStart+c+2))"
-        # Only output the second line if the time is at least 100 ms instead of the following:
-        # PING 192.168.123.194 (192.168.123.194): 56 data bytes
-        # 64 bytes from 192.168.123.194: seq=0 ttl=64 time=13.658 ms
-        #
-        # --- 192.168.123.194 ping statistics ---
-        # 1 packets transmitted, 1 packets received, 0% packet loss
-        # round-trip min/avg/max = 13.658/13.658/13.658 ms
-        ping -W 2 -w 2 -c 1 $ip | sed '/\(^PING.*\|^---.*---$\|.*1 packets received.*\|^round-trip.*\|^$\|.*time=.\?..... ms$\)/d' &
+        ping -W 2 -w 2 -c 1 $ip > /tmp/ping-result-$c &
         ping_pid[$ip]=$!
     done
 
@@ -93,6 +86,14 @@ function pingAllShootClients() {
         else
           ping_return_msg[$ip]="err"
         fi
+        # Only output the second line if the time is at least 100 ms instead of the following:
+        # PING 192.168.123.194 (192.168.123.194): 56 data bytes
+        # 64 bytes from 192.168.123.194: seq=0 ttl=64 time=13.658 ms
+        #
+        # --- 192.168.123.194 ping statistics ---
+        # 1 packets transmitted, 1 packets received, 0% packet loss
+        # round-trip min/avg/max = 13.658/13.658/13.658 ms
+        sed '/\(^PING.*\|^---.*---$\|.*1 packets received.*\|^round-trip.*\|^$\|.*time=.\?..... ms$\)/d' /tmp/ping-result-$c
     done
     set -e
 }

--- a/shoot-client/path-controller.sh
+++ b/shoot-client/path-controller.sh
@@ -67,7 +67,14 @@ function pingAllShootClients() {
     set +e
     for (( c=0; c<$HA_VPN_CLIENTS; c++ )); do
         ip="${bondPrefix}.$((bondStart+c+2))"
-        ping -W 2 -w 2 -c 1 $ip > /dev/null &
+        # Only output the second line if the time is at least 100 ms instead of the following:
+        # PING 192.168.123.194 (192.168.123.194): 56 data bytes
+        # 64 bytes from 192.168.123.194: seq=0 ttl=64 time=13.658 ms
+        #
+        # --- 192.168.123.194 ping statistics ---
+        # 1 packets transmitted, 1 packets received, 0% packet loss
+        # round-trip min/avg/max = 13.658/13.658/13.658 ms
+        ping -W 2 -w 2 -c 1 $ip | sed '/\(^PING.*\|^---.*---$\|.*1 packets received.*\|^round-trip.*\|^$\|.*time=...... ms$\)/d' &
         ping_pid[$ip]=$!
     done
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Print ping messages taking more than 100 ms.

In case a ping message in path controller takes more than two seconds the connections is assumed to be broken. However, ICMP messages may get dropped or drowned in a load of traffic. Therefore, it might be interesting to at least see if some messages took longer than usual.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

`sed` is used instead of `grep` as it is already available in the container.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
The vpn-path-controller now outputs ping replies taking more than 100 ms
```

/cc @MartinWeindel @rfranzke @axel7born 