### PR TITLE
enable ipv6 for GKE clusters

### DIFF
--- a/cmd/vpn_client/app/setup/setup.go
+++ b/cmd/vpn_client/app/setup/setup.go
@@ -41,7 +41,7 @@ func run(ctx context.Context, _ context.CancelFunc, log logr.Logger) error {
 	}
 	log.Info("config parsed", "config", cfg)
 
-	err = vpn_client.KernelSettings(cfg)
+	err = vpn_client.KernelSettings(log, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -5,15 +5,31 @@
 package vpn_client
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/gardener/vpn2/pkg/config"
+	"github.com/go-logr/logr"
 )
 
 // KernelSettings sets the kernel parameters required for the VPN tunnel to function properly.
-func KernelSettings(cfg config.VPNClient) error {
+func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	if !cfg.IsShootClient {
+		value, err := sysctl.ReadInt("net.ipv6.conf.all.disable_ipv6")
+		if err != nil {
+			return fmt.Errorf("failed to read net.ipv6.conf.all.disable_ipv6: %w", err)
+		}
+		if value == 1 {
+			log.Info("IPv6 networking is disabled in the pod, trying to enable it")
+			// Enable IPv6 networking on the system (needed for GKE clusters)
+			if err := sysctl.Disable("net.ipv6.conf.all.disable_ipv6"); err != nil {
+				return fmt.Errorf("failed to enable IPv6 networking: %w (hint: container may need to be privileged)", err)
+			}
+			log.Info("IPv6 networking enabled")
+		}
 		return nil
 	}
+
 	// Enable IPv4 forwarding on the system.
 	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding an IPv6 address to the bonding device fails for the `vpn-client-init` container on GKE clusters with IPv4 stack only.
This fix enables IPv6 in the pod by writing `sysctl -w net.ipv6.conf.all.disable_ipv6=0` if needed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Enable IPv6 for the pod network if needed.
```
