### PR TITLE
Refer to step check instead of non-existing step verify

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -89,7 +89,7 @@ vpn2:
           nextversion: 'bump_minor'
           assets:
           - type: build-step-log
-            step_name: verify
+            step_name: check
             purposes:
             - lint
             - sast


### PR DESCRIPTION
**What this PR does / why we need it**:
Refer to step check instead of non-existing step verify


**Special notes for your reviewer**:
Follow-up/fix of PR  #109 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
NONE
```
