### PR TITLE
Revert "Simplify config."

### DIFF
--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gardener/vpn2/cmd/vpn_client/app/pathcontroller"
 	"github.com/gardener/vpn2/cmd/vpn_client/app/setup"
@@ -55,6 +56,7 @@ func NewCommand() *cobra.Command {
 func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 	v := openvpn.ClientValues{
 		Device:            "tun0",
+		IPFamily:          cfg.PrimaryIPFamily(),
 		ReversedVPNHeader: cfg.ReversedVPNHeader,
 		Endpoint:          cfg.Endpoint,
 		OpenVPNPort:       cfg.OpenVPNPort,
@@ -64,6 +66,10 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		SeedPodNetwork:    cfg.SeedPodNetwork.String(),
 	}
 	vpnSeedServer := "vpn-seed-server"
+
+	if len(strings.Split(cfg.IPFamilies, ",")) == 2 {
+		v.IsDualStack = true
+	}
 
 	if cfg.VPNServerIndex != "" {
 		vpnSeedServer = fmt.Sprintf("vpn-seed-server-%s", cfg.VPNServerIndex)

--- a/pkg/config/pathcontroller.go
+++ b/pkg/config/pathcontroller.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"strings"
 
 	"github.com/caarlos0/env/v10"
 	"github.com/gardener/vpn2/pkg/network"
@@ -20,6 +21,9 @@ type PathController struct {
 	ServiceNetwork network.CIDR `env:"SERVICE_NETWORK"`
 }
 
+func (v PathController) PrimaryIPFamily() string {
+	return strings.Split(v.IPFamilies, ",")[0]
+}
 
 func GetPathControllerConfig(log logr.Logger) (PathController, error) {
 	cfg := PathController{}

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -37,6 +37,10 @@ type VPNClient struct {
 	WaitTime          time.Duration `env:"WAIT_TIME" envDefault:"2s"`
 }
 
+func (v VPNClient) PrimaryIPFamily() string {
+	return strings.Split(v.IPFamilies, ",")[0]
+}
+
 func GetVPNClientConfig() (VPNClient, error) {
 	cfg := VPNClient{}
 	if err := env.Parse(&cfg); err != nil {

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"strings"
 
 	"github.com/caarlos0/env/v10"
 	"github.com/gardener/vpn2/pkg/network"
@@ -22,6 +23,10 @@ type VPNServer struct {
 	IsHA            bool           `env:"IS_HA"`
 	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
 	LocalNodeIP     string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
+}
+
+func (v VPNServer) PrimaryIPFamily() string {
+	return strings.Split(v.IPFamilies, ",")[0]
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -17,7 +17,13 @@ tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 1
 # https://openvpn.net/index.php/open-source/documentation/howto.html#mitm
 remote-cert-tls server
 
+{{- if .IsDualStack }}
 proto tcp-client
+{{- else if (eq .IPFamily "IPv4") }}
+proto tcp4-client
+{{- else if (eq .IPFamily "IPv6") }}
+proto tcp6-client
+{{- end }}
 
 {{- if (eq .VPNClientIndex -1) }}
 key /srv/secrets/vpn-client/tls.key

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -25,7 +25,13 @@ dh none
 auth SHA256
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 
+{{- if .IsDualStack }}
 proto tcp-server
+{{- else if (eq .IPFamily "IPv4") }}
+proto tcp4-server
+{{- else if (eq .IPFamily "IPv6") }}
+proto tcp6-server
+{{- end }}
 
 server-ipv6 {{ printf "%s" .OpenVPNNetwork }}
 

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -16,6 +16,7 @@ import (
 var clientTemplate string
 
 type ClientValues struct {
+	IPFamily          string
 	ReversedVPNHeader string
 	Endpoint          string
 	OpenVPNPort       int
@@ -24,6 +25,7 @@ type ClientValues struct {
 	IsHA              bool
 	Device            string
 	SeedPodNetwork    string
+	IsDualStack       bool
 }
 
 func generateClientConfig(cfg ClientValues) (string, error) {

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -23,6 +23,7 @@ var (
 
 type SeedServerValues struct {
 	Device          string
+	IPFamily        string
 	StatusPath      string
 	OpenVPNNetwork  network.CIDR
 	ShootNetworks   []network.CIDR
@@ -32,6 +33,7 @@ type SeedServerValues struct {
 	IsHA            bool
 	VPNIndex        int
 	LocalNodeIP     string
+	IsDualStack     bool
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -28,6 +28,7 @@ var _ = Describe("#SeedServerConfig", func() {
 
 	BeforeEach(func() {
 		cfgIPv4 = SeedServerValues{
+			IsDualStack:    false,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -41,8 +42,10 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("100.96.0.0/11"),
 				parseIPNet("10.0.1.0/24"),
 			},
+			IPFamily: "IPv4",
 		}
 		cfgIPv6 = SeedServerValues{
+			IsDualStack:    false,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -56,8 +59,10 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("2001:db8:2::/48"),
 				parseIPNet("2001:db8:3::/48"),
 			},
+			IPFamily: "IPv6",
 		}
 		cfgDualStack = SeedServerValues{
+			IsDualStack:    true,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -79,6 +84,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("2001:db8:2::/48"),
 				parseIPNet("2001:db8:3::/48"),
 			},
+			IPFamily: "IPv6",
 		}
 	})
 
@@ -89,7 +95,7 @@ var _ = Describe("#SeedServerConfig", func() {
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp-server
+			Expect(content).To(ContainSubstring(`proto tcp4-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))
@@ -110,7 +116,7 @@ down "/bin/vpn-server firewall --mode down --device tun0"`))
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp-server
+			Expect(content).To(ContainSubstring(`proto tcp4-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))
@@ -140,7 +146,7 @@ status-version 2`))
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp-server
+			Expect(content).To(ContainSubstring(`proto tcp6-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
@@ -18,6 +19,7 @@ import (
 
 func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 	v := openvpn.SeedServerValues{
+		IPFamily:   cfg.PrimaryIPFamily(),
 		StatusPath: cfg.StatusPath,
 	}
 
@@ -35,6 +37,10 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		} else {
 			v.ShootNetworksV6 = append(v.ShootNetworksV6, shootNetwork)
 		}
+	}
+
+	if len(strings.Split(cfg.IPFamilies, ",")) == 2 {
+		v.IsDualStack = true
 	}
 
 	v.IsHA, v.VPNIndex = getHAInfo()


### PR DESCRIPTION
This reverts commit 3abf68bf61216bf4215fda780b62e35f3920573a.

**What this PR does / why we need it**:
The simplified config breaks the ipv6 only case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Fix an issue, where the liveness probe of vpn-server is failing in IPv6 only clusters.
```
