### PR TITLE
Fix logging for created routes from vpn-path-controller.

### DIFF
--- a/cmd/vpn_client/app/pathcontroller/pathcontroller.go
+++ b/cmd/vpn_client/app/pathcontroller/pathcontroller.go
@@ -56,6 +56,7 @@ func run(ctx context.Context, _ context.CancelFunc, log logr.Logger) error {
 	netlinkRouter := &netlinkRouter{
 		podNetwork:     (*net.IPNet)(&cfg.PodNetwork),
 		serviceNetwork: (*net.IPNet)(&cfg.ServiceNetwork),
+		log:            log,
 	}
 	if cfg.NodeNetwork.String() != "" {
 		netlinkRouter.nodeNetwork = (*net.IPNet)(&cfg.NodeNetwork)


### PR DESCRIPTION
**What this PR does / why we need it**:
The method `netlinkRouter.updateRouting` logs the creation of routes. As log field is not set, these log messages are not visible.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fix logging for created routes from vpn-path-controller.
```
