### PR TITLE
Create routes in kube-apiserver pods to both IPv6 and IPv4 ranges.

### DIFF
--- a/cmd/vpn_client/app/setup/setup.go
+++ b/cmd/vpn_client/app/setup/setup.go
@@ -37,6 +37,7 @@ func NewCommand() *cobra.Command {
 func run(ctx context.Context, _ context.CancelFunc, log logr.Logger) error {
 	cfg, err := config.GetVPNClientConfig()
 	if err != nil {
+		log.Info("failed to parse config", "error", err)
 		return err
 	}
 	log.Info("config parsed", "config", cfg)

--- a/pkg/config/pathcontroller.go
+++ b/pkg/config/pathcontroller.go
@@ -13,12 +13,12 @@ import (
 )
 
 type PathController struct {
-	IPFamilies     string       `env:"IP_FAMILIES" envDefault:"IPv4"`
-	VPNNetwork     network.CIDR `env:"VPN_NETWORK"`
-	HAVPNClients   int          `env:"HA_VPN_CLIENTS"`
-	PodNetwork     network.CIDR `env:"POD_NETWORK"`
-	NodeNetwork    network.CIDR `env:"NODE_NETWORK"`
-	ServiceNetwork network.CIDR `env:"SERVICE_NETWORK"`
+	IPFamilies      string         `env:"IP_FAMILIES" envDefault:"IPv4"`
+	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
+	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
+	ServiceNetworks []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
+	PodNetworks     []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
+	NodeNetworks    []network.CIDR `env:"NODE_NETWORKS"`
 }
 
 func (v PathController) PrimaryIPFamily() string {

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -5,12 +5,12 @@
 package vpn_client
 
 import (
-	"strings"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
 	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
+	"strings"
 )
 
 func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Create routes in kube-apiserver pods to both IPv6 and IPv4 ranges.

Depends on https://github.com/gardener/gardener/pull/10970

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Create routes in kube-apiserver pods to both IPv6 and IPv4 ranges.
```
