### PR TITLE
IPv6 needs to be enabled on GKE for non-HA 

### DIFF
--- a/cmd/vpn_server/app/setup/setup.go
+++ b/cmd/vpn_server/app/setup/setup.go
@@ -7,7 +7,6 @@ package setup
 import (
 	"context"
 
-	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/utils"
 	"github.com/gardener/vpn2/pkg/vpn_client"
 	"github.com/go-logr/logr"
@@ -35,16 +34,5 @@ func NewCommand() *cobra.Command {
 }
 
 func run(_ context.Context, _ context.CancelFunc, log logr.Logger) error {
-	cfg, err := config.GetVPNServerConfig(log)
-	if err != nil {
-		return err
-	}
-
-	if cfg.IsHA {
-		err = vpn_client.EnableIPv6Networking(log)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return vpn_client.EnableIPv6Networking(log)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The fix for GKE clusters to enable `IPv6` explicitly was only applied for the VPN-HA case. It must also be applied for the non HA case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #107 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Enable IPv6 for the pod network if needed (non HA).
```
