### PR TITLE
Fix ping failure due to overflow in sequence number check

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please see [Reversed VPN Tunnel Setup and Configuration](https://github.com/gard
   *Note: Remember the image name reported at the end similar to*  
 
   ```txt
-  VPN client image: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-client:0.26.0-dev
+  VPN client image: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-client:0.33.0-dev
   ```
 
   **VPN server image**
@@ -76,22 +76,22 @@ Please see [Reversed VPN Tunnel Setup and Configuration](https://github.com/gard
   *Note: Remember the image name reported at the end similar to*
 
   ```txt
-  VPN server image: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-server:0.26.0-dev
+  VPN server image: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-server:0.33.0-dev
   ```
 
-- adjust the image vector file `imagevector/images.yaml` in Gardener to image repositories and tags provided by the last step
+- adjust the image vector file `imagevector/containers.yaml` in Gardener to image repositories and tags provided by the last step
 
   ```
   ...
   - name: vpn-server
   sourceRepository: github.com/gardener/vpn2
   repository: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-server
-  tag: 0.26.0-dev
+  tag: 0.33.0-dev
   ...
   - name: vpn-client
   sourceRepository: github.com/gardener/vpn2
   repository: localhost:5001/europe-docker_pkg_dev_gardener-project_public_gardener_vpn-client
-  tag: 0.26.0-dev
+  tag: 0.33.0-dev
   ...
   ```
 

--- a/cmd/vpn_client/app/pathcontroller/ping.go
+++ b/cmd/vpn_client/app/pathcontroller/ping.go
@@ -84,12 +84,12 @@ func (p *icmpPinger) ping(client net.IP) error {
 		return fmt.Errorf("error setting deadline: %w", err)
 	}
 
-	seq := p.lastSeq.Add(1)
+	seq := p.lastSeq.Add(1) & 0xffff // is marshalled as uint16 so we need to mask it
 	msg := icmp.Message{
 		Type: ipv6.ICMPTypeEchoRequest,
 		Code: 0,
 		Body: &icmp.Echo{
-			ID:   os.Getpid() & 0xffff,
+			ID:   os.Getpid() & 0xffff, // is marshalled as uint16 so we need to mask it
 			Seq:  int(seq),
 			Data: []byte(echoPayload),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
The vpn-path-controller performs regular pings to both vpn-shoot pods in the VPN HA setup.
The ping response are validated. Especially the ping sequence number is compared.
The sequence number is marshalled as 16-bit integer, but uses a 32-bit counter in the code.
The comparison for long running kube-apiserver pods starts to fails after about 36h, and none of the both VPN tunnels can be used anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fix ping failure due to 16bit overflow in sequence number check.
```
