### PR TITLE
Tunnelcontroller for HA: Fix ip6tnl suffix to use two last bytes

### DIFF
--- a/pkg/shoot_client/tunnel/tunnel.go
+++ b/pkg/shoot_client/tunnel/tunnel.go
@@ -73,12 +73,7 @@ func (d *kubeApiserverData) update() {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	name, err := d.linkName()
-	if err != nil {
-		d._setFailed(err)
-		return
-	}
-
+	name := d.linkName()
 	if err := network.DeleteLinkByName(name); err != nil {
 		d._setFailed(fmt.Errorf("failed to delete link %s: %w", name, err))
 		return
@@ -120,12 +115,7 @@ func (d *kubeApiserverData) delete() {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	name, err := d.linkName()
-	if err != nil {
-		d._setFailed(err)
-		return
-	}
-
+	name := d.linkName()
 	if err := network.DeleteLinkByName(name); err != nil {
 		d.log.Error(err, "failed to delete old tunnel device", "name", name)
 	} else {
@@ -133,12 +123,10 @@ func (d *kubeApiserverData) delete() {
 	}
 }
 
-func (d *kubeApiserverData) linkName() (string, error) {
-	s := fmt.Sprintf("%sip6tnl%02x%02x", constants.BondDevice, d.remoteAddr[len(d.remoteAddr)-2], d.remoteAddr[len(d.remoteAddr)-1])
-	if len(s) > 15 {
-		return "", fmt.Errorf("link name too long: %s", s)
-	}
-	return s, nil
+func (d *kubeApiserverData) linkName() string {
+	// link name must be unique, so we use the last two bytes of the remote address as it is chosen from a /112 range.
+	// The link name must be 15 characters or less in Linux.
+	return fmt.Sprintf("%sip6tnl%02x%02x", constants.BondDevice, d.remoteAddr[len(d.remoteAddr)-2], d.remoteAddr[len(d.remoteAddr)-1])
 }
 
 func (d *kubeApiserverData) _setFailed(err error) {
@@ -215,6 +203,12 @@ func (c *Controller) Run(log logr.Logger) error {
 				podIP:      podIP,
 			}
 			c.kubeApiservers[key] = data
+			// edge case: if the remoteAddr was used by another kube-apiserver before and cleanup has not run yet, the entry must be removed
+			for k, d := range c.kubeApiservers {
+				if k != key && data.remoteAddr.Equal(d.remoteAddr) {
+					delete(c.kubeApiservers, k)
+				}
+			}
 		}
 		c.lock.Unlock()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The tunnel-controller running in the vpn-shoot pods for VPN HA must create ip6 tunnel devices with unique names for each kube-apiserver. For that purpose its IPv6 address in the bonding tunnel network is used.
By mistake, only the last byte of the address was used for naming, but the IPv6 addresses are chosen randomly in the /112 subrange, i.e. the last two bytes must be considered.
Therefore, when two kube-apiserver with the same last byte have been created, there was a clash in the tunnel device name causing deletion of still needed tunnel devices and destroying the connection to these kube-apiservers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Tunnelcontroller for HA: Fix ip6tnl suffix to use two last bytes
```
