### PR TITLE
Always listen on both IPv4 and IPv6 sockets on server side.

### DIFF
--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -5,15 +5,12 @@
 package config
 
 import (
-	"strings"
-
 	"github.com/caarlos0/env/v10"
 	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
 )
 
 type VPNServer struct {
-	IPFamilies      string         `env:"IP_FAMILIES" envDefault:"IPv4"`
 	ServiceNetworks []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
 	PodNetworks     []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
 	NodeNetworks    []network.CIDR `env:"NODE_NETWORKS"`
@@ -23,10 +20,6 @@ type VPNServer struct {
 	IsHA            bool           `env:"IS_HA"`
 	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
 	LocalNodeIP     string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
-}
-
-func (v VPNServer) PrimaryIPFamily() string {
-	return strings.Split(v.IPFamilies, ",")[0]
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -25,13 +25,8 @@ dh none
 auth SHA256
 tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 
-{{- if .IsDualStack }}
-proto tcp-server
-{{- else if (eq .IPFamily "IPv4") }}
-proto tcp4-server
-{{- else if (eq .IPFamily "IPv6") }}
+# always listen on both IPv4 & IPv6 via tcp6-server
 proto tcp6-server
-{{- end }}
 
 server-ipv6 {{ printf "%s" .OpenVPNNetwork }}
 

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -23,7 +23,6 @@ var (
 
 type SeedServerValues struct {
 	Device          string
-	IPFamily        string
 	StatusPath      string
 	OpenVPNNetwork  network.CIDR
 	ShootNetworks   []network.CIDR
@@ -33,7 +32,6 @@ type SeedServerValues struct {
 	IsHA            bool
 	VPNIndex        int
 	LocalNodeIP     string
-	IsDualStack     bool
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -28,7 +28,6 @@ var _ = Describe("#SeedServerConfig", func() {
 
 	BeforeEach(func() {
 		cfgIPv4 = SeedServerValues{
-			IsDualStack:    false,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -42,10 +41,8 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("100.96.0.0/11"),
 				parseIPNet("10.0.1.0/24"),
 			},
-			IPFamily: "IPv4",
 		}
 		cfgIPv6 = SeedServerValues{
-			IsDualStack:    false,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -59,10 +56,8 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("2001:db8:2::/48"),
 				parseIPNet("2001:db8:3::/48"),
 			},
-			IPFamily: "IPv6",
 		}
 		cfgDualStack = SeedServerValues{
-			IsDualStack:    true,
 			Device:         "tun0",
 			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
@@ -84,7 +79,6 @@ var _ = Describe("#SeedServerConfig", func() {
 				parseIPNet("2001:db8:2::/48"),
 				parseIPNet("2001:db8:3::/48"),
 			},
-			IPFamily: "IPv6",
 		}
 	})
 
@@ -95,7 +89,7 @@ var _ = Describe("#SeedServerConfig", func() {
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp4-server
+			Expect(content).To(ContainSubstring(`proto tcp6-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))
@@ -116,7 +110,7 @@ down "/bin/vpn-server firewall --mode down --device tun0"`))
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp4-server
+			Expect(content).To(ContainSubstring(`proto tcp6-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))
@@ -165,7 +159,7 @@ down "/bin/vpn-server firewall --mode down --device tun0"`))
 
 			Expect(content).To(ContainSubstring(`tls-auth "/srv/secrets/tlsauth/vpn.tlsauth" 0
 `))
-			Expect(content).To(ContainSubstring(`proto tcp-server
+			Expect(content).To(ContainSubstring(`proto tcp6-server
 
 server-ipv6 fd8f:6d53:b97a:7777::/96
 `))

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
@@ -19,7 +18,6 @@ import (
 
 func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 	v := openvpn.SeedServerValues{
-		IPFamily:   cfg.PrimaryIPFamily(),
 		StatusPath: cfg.StatusPath,
 	}
 
@@ -37,10 +35,6 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		} else {
 			v.ShootNetworksV6 = append(v.ShootNetworksV6, shootNetwork)
 		}
-	}
-
-	if len(strings.Split(cfg.IPFamilies, ",")) == 2 {
-		v.IsDualStack = true
 	}
 
 	v.IsHA, v.VPNIndex = getHAInfo()


### PR DESCRIPTION
**What this PR does / why we need it**:

Always listen on both IPv4 and IPv6 sockets on server side.

To simplify the configuration by removing unnecessary options and make it easier to support dual-stack configurations on server side with single-stack on client side, the vpn server is configured to always listen on both IPv4 as well as IPv6 sockets. Unfortunately, this is achieved via the unintuitive `tcp6-server` option. Looking at it via tools like `netstat` or `ss`, it looks like there is only an IPv6 socket, but you can also address it via IPv4.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Always listen on both IPv4 and IPv6 sockets on server side.
```
