### PR TITLE
Set reasonable MTU values for network interfaces.

### DIFF
--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -40,7 +40,7 @@ func CreateTunnel(linkName string, local, remote net.IP) error {
 	tunnel := &netlink.Ip6tnl{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: linkName,
-			MTU: 1380,
+			MTU: 1312,
 		},
 		Local:  local,
 		Remote: remote,
@@ -48,7 +48,6 @@ func CreateTunnel(linkName string, local, remote net.IP) error {
 	if err := netlink.LinkAdd(tunnel); err != nil {
 		return fmt.Errorf("failed to add link %s: %w", linkName, err)
 	}
-
 	if err := netlink.LinkSetUp(tunnel); err != nil {
 		return fmt.Errorf("failed to set up link %s: %w", linkName, err)
 	}

--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -40,6 +40,7 @@ func CreateTunnel(linkName string, local, remote net.IP) error {
 	tunnel := &netlink.Ip6tnl{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: linkName,
+			MTU: 1380,
 		},
 		Local:  local,
 		Remote: remote,
@@ -47,6 +48,7 @@ func CreateTunnel(linkName string, local, remote net.IP) error {
 	if err := netlink.LinkAdd(tunnel); err != nil {
 		return fmt.Errorf("failed to add link %s: %w", linkName, err)
 	}
+
 	if err := netlink.LinkSetUp(tunnel); err != nil {
 		return fmt.Errorf("failed to set up link %s: %w", linkName, err)
 	}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -7,10 +7,7 @@ txqueuelen 1000
 pull
 data-ciphers AES-256-GCM
 tls-client
-
-link-mtu 1440
-mssfix 1340
-
+tun-mtu 1312
 verb 4
 
 # retry every second, increase retry timeout to max 5

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -8,6 +8,11 @@ pull
 data-ciphers AES-256-GCM
 tls-client
 
+link-mtu 1440
+mssfix 1340
+
+verb 4
+
 # retry every second, increase retry timeout to max 5
 connect-retry 1 5
 

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -11,10 +11,7 @@ data-ciphers AES-256-GCM:AES-256-CBC
 # port can be configured for the external load balancer in the service
 # manifest
 port 1194
-
-tun-mtu 1380
-mssfix 1340
-
+tun-mtu 1312
 verb 4
 
 keepalive 10 60

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -12,6 +12,11 @@ data-ciphers AES-256-GCM:AES-256-CBC
 # manifest
 port 1194
 
+tun-mtu 1380
+mssfix 1340
+
+verb 4
+
 keepalive 10 60
 
 # client-config-dir to push client specific configuration

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -89,7 +89,9 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 	if err = netlink.LinkAdd(bond); err != nil {
 		return fmt.Errorf("failed to create %s link device: %w", constants.BondDevice, err)
 	}
-
+	if err := netlink.LinkSetMTU(bond, 1380); err != nil {
+		return fmt.Errorf("failed to set MTU %s: %w", constants.BondDevice, err)
+	}
 	for i := range cfg.HAVPNServers {
 		linkName := fmt.Sprintf("tap%d", i)
 

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -89,7 +89,7 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 	if err = netlink.LinkAdd(bond); err != nil {
 		return fmt.Errorf("failed to create %s link device: %w", constants.BondDevice, err)
 	}
-	if err := netlink.LinkSetMTU(bond, 1380); err != nil {
+	if err := netlink.LinkSetMTU(bond, 1312); err != nil {
 		return fmt.Errorf("failed to set MTU %s: %w", constants.BondDevice, err)
 	}
 	for i := range cfg.HAVPNServers {


### PR DESCRIPTION
**What this PR does / why we need it**:
In shoots with HA VPN, we see cached MTU values to pods running on the same node as `vpn-shoot-i` pods. This leads to MTU issues for traffic to pods, that are exposed via loadbalancer services with `ExternalTrafficPolicy: Cluster`. ICMP messages are often not send back to a client (blocked by loadbalancer or NAT gateway) and connections with large packets fail.
Though, the issue is not completely understood, adapting Openvpn MTU values to reasonable values, considering a path MTU of 1440 in clusters that use overlay network, seems to resolve the issue.

`tun-mtu` is set to lower value accounting for encapsulation, encryption, etc.

The change increases the log level.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Set reasonable MTU values for network interfaces.
```
