### PR TITLE
Add iptables rules to set mss to pmtu.

### DIFF
--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -37,6 +37,11 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				}
 			}
 
+			err = ipTable.Append("filter", "FORWARD", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--clamp-mss-to-pmtu")
+			if err != nil {
+				return err
+			}
+
 			err = ipTable.Append("nat", "POSTROUTING", "--out-interface", "eth0", "-j", "MASQUERADE")
 			if err != nil {
 				return err


### PR DESCRIPTION
Setting MSS avoids TCP connections with to large values or MSS, resulting in packet sizes that exceed device MTUs. 
This avoids ICMP messages due to to large packets resulting in small MTU values in route caches in case of overlay network.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Add iptables rules to set mss to pmtu.
```
