### PR TITLE
Seed shoot range overlap

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,110 @@
+run:
+  concurrency: 4
+  timeout: 10m
+
+issues:
+  exclude-files:
+    - "zz_generated\\..*\\.go$"
+
+linters:
+  disable:
+  - unused
+  enable:
+  - gci
+  - importas
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - localmodule
+    skip-generated: true
+    custom-order: true
+
+  importas:
+    # Source: github.com/gardener/gardener/.golangci.yaml
+    alias:
+      # External imported packages
+      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/apis/(\w+)/(v[\w\d]+)
+        alias: $1$2
+      - pkg: k8s.io/apimachinery/pkg/api/([^m]\w+)
+        alias: api${1}
+      - pkg: k8s.io/apimachinery/pkg/util/(\w+)
+        alias: util${1}
+      - pkg: k8s.io/client-go/kubernetes
+        alias: kubernetesclientset
+      - pkg: k8s.io/client-go/tools/clientcmd/api/(\w+)
+        alias: clientcmd${1}
+      - pkg: k8s.io/component-base/config
+        alias: componentbaseconfig
+      - pkg: k8s.io/component-base/logs/api/v1
+        alias: logsv1
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client/fake
+        alias: fakeclient
+      - pkg: sigs.k8s.io/controller-runtime/pkg/log/zap
+        alias: logzap
+      - pkg: sigs.k8s.io/controller-runtime/pkg/log
+        alias: logf
+      - pkg: go.uber.org/mock/gomock
+        alias: gmock
+      # Gardener extension package
+      - pkg: github.com/gardener/gardener/extensions/.*/(\w+)/mock$
+        alias: extensionsmock${1}
+      - pkg: github.com/gardener/gardener/extensions/pkg/apis/config
+        alias: extensionsconfig
+      - pkg: github.com/gardener/gardener/extensions/pkg/controller
+        alias: extensionscontroller
+      - pkg: github.com/gardener/gardener/extensions/pkg/predicate
+        alias: extensionspredicate
+      - pkg: github.com/gardener/gardener/extensions/pkg/controller/([^m]\w+)
+        alias: extensions${1}controller
+      - pkg: github.com/gardener/gardener/extensions/pkg/controller/heartbeat/cmd
+        alias: extensionsheartbeatcmd
+      - pkg: github.com/gardener/gardener/extensions/pkg/controller/worker/helper
+        alias: extensionsworkerhelper
+      - pkg: github.com/gardener/gardener/extensions/pkg/util/secret/manager
+        alias: extensionssecretsmanager
+      - pkg: github.com/gardener/gardener/extensions/pkg/webhook
+        alias: extensionswebhook
+      - pkg: github.com/gardener/gardener/extensions/pkg/webhook/([^m]\w+)
+        alias:  extensions${1}webhook
+      # Gardener other packages
+      - pkg: github.com/gardener/gardener/pkg/api/extensions
+        alias: apiextensions
+      - pkg: github.com/gardener/gardener/pkg/apis/core
+        alias: gardencore
+      - pkg: github.com/gardener/gardener/pkg/apis/core/([\w\d]+)
+        alias: gardencore${1}
+      - pkg: github.com/gardener/gardener/pkg/apis/core/([\w\d]+)/helper
+        alias: ${1}helper
+      - pkg: github.com/gardener/gardener/pkg/apis/core/([\w\d]+)/constants
+        alias: ${1}constants
+      - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)
+        alias: $1$2
+      - pkg: github.com/gardener/gardener/pkg/apis/([^c]\w+)/([\w\d]+)/([\w\d]+)
+        alias: $1$2$3
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config
+        alias: ${1}config
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/apis/config/([\w\d]+)
+        alias: $1$2
+      - pkg: github.com/gardener/gardener/pkg/(\w+)/features
+        alias: ${1}features
+      - pkg: github.com/gardener/gardener/pkg/\w+/controller/([\w\d]+)
+        alias: ${1}controller
+      - pkg: github.com/gardener/gardener/pkg/\w+/webhook/([\w\d]+)
+        alias: ${1}webhook
+      - pkg: github.com/gardener/gardener/pkg/client/kubernetes
+        alias: kubernetesclient
+      - pkg: github.com/gardener/gardener/pkg/client/kubernetes/(\w+)
+        alias: kubernetes${1}
+      - pkg: github.com/gardener/gardener/pkg/controllerutils/(\w+)
+        alias: ${1}utils
+      - pkg: github.com/gardener/gardener/pkg/extensions
+        alias: gardenerextensions
+      - pkg: github.com/gardener/gardener/pkg/component/(\w+)/constants
+        alias: ${1}constants
+      - pkg: github.com/gardener/gardener/pkg/utils/(\w+)
+        alias: ${1}utils

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ## base
-FROM alpine:3.21.3 as base
+FROM alpine:3.21.3 AS base
 
 RUN apk add --update openvpn iptables iptables-legacy && \
     rm -rf /var/cache/apk/*

--- a/cmd/tunnel_controller/app/app.go
+++ b/cmd/tunnel_controller/app/app.go
@@ -5,9 +5,10 @@
 package app
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/gardener/vpn2/pkg/shoot_client/tunnel"
 	"github.com/gardener/vpn2/pkg/utils"
-	"github.com/spf13/cobra"
 )
 
 const Name = "tunnel-controller"

--- a/cmd/tunnel_controller/main.go
+++ b/cmd/tunnel_controller/main.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gardener/vpn2/cmd/tunnel_controller/app"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/gardener/vpn2/cmd/tunnel_controller/app"
 )
 
 func main() {

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -9,6 +9,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/version/verflag"
+
 	"github.com/gardener/vpn2/cmd/vpn_client/app/pathcontroller"
 	"github.com/gardener/vpn2/cmd/vpn_client/app/setup"
 	"github.com/gardener/vpn2/pkg/config"
@@ -17,9 +21,6 @@ import (
 	"github.com/gardener/vpn2/pkg/pprof"
 	"github.com/gardener/vpn2/pkg/utils"
 	"github.com/gardener/vpn2/pkg/vpn_client"
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
-	"k8s.io/component-base/version/verflag"
 )
 
 // Name is a const for the name of this component.

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -7,8 +7,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/version/verflag"
@@ -69,7 +67,7 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 	}
 	vpnSeedServer := "vpn-seed-server"
 
-	if len(strings.Split(cfg.IPFamilies, ",")) == 2 {
+	if len(cfg.IPFamilies) == 2 {
 		v.IsDualStack = true
 	}
 

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -56,21 +56,24 @@ func NewCommand() *cobra.Command {
 
 func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 	v := openvpn.ClientValues{
-		Device:               constants.TunnelDevice,
-		IPFamily:             cfg.PrimaryIPFamily(),
-		ReversedVPNHeader:    cfg.ReversedVPNHeader,
-		Endpoint:             cfg.Endpoint,
-		OpenVPNPort:          cfg.OpenVPNPort,
-		VPNClientIndex:       cfg.VPNClientIndex,
-		IsShootClient:        cfg.IsShootClient,
-		IsHA:                 cfg.IsHA,
-		SeedPodNetwork:       cfg.SeedPodNetwork.String(),
-		SeedPodNetworkMapped: constants.SeedPodNetworkMapped,
+		Device:            constants.TunnelDevice,
+		IPFamily:          cfg.PrimaryIPFamily(),
+		ReversedVPNHeader: cfg.ReversedVPNHeader,
+		Endpoint:          cfg.Endpoint,
+		OpenVPNPort:       cfg.OpenVPNPort,
+		VPNClientIndex:    cfg.VPNClientIndex,
+		IsShootClient:     cfg.IsShootClient,
+		IsHA:              cfg.IsHA,
+		SeedPodNetwork:    cfg.SeedPodNetwork.String(),
 	}
 	vpnSeedServer := "vpn-seed-server"
 
 	if len(strings.Split(cfg.IPFamilies, ",")) == 2 {
 		v.IsDualStack = true
+	}
+
+	if !cfg.IsHA && cfg.SeedPodNetwork.IsIPv4() {
+		v.SeedPodNetwork = constants.SeedPodNetworkMapped
 	}
 
 	if cfg.VPNServerIndex != "" {

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -56,7 +56,7 @@ func NewCommand() *cobra.Command {
 
 func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 	v := openvpn.ClientValues{
-		Device:               "tun0",
+		Device:               constants.TunnelDevice,
 		IPFamily:             cfg.PrimaryIPFamily(),
 		ReversedVPNHeader:    cfg.ReversedVPNHeader,
 		Endpoint:             cfg.Endpoint,

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/version/verflag"

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -65,7 +65,7 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		VPNClientIndex:    cfg.VPNClientIndex,
 		IsShootClient:     cfg.IsShootClient,
 		IsHA:              cfg.IsHA,
-		SeedPodNetwork:    cfg.SeedPodNetwork.String(),
+		SeedPodNetworkV4:  cfg.SeedPodNetworkV4.String(),
 	}
 	vpnSeedServer := "vpn-seed-server"
 
@@ -73,8 +73,8 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		v.IsDualStack = true
 	}
 
-	if !cfg.IsHA && cfg.SeedPodNetwork.IsIPv4() {
-		v.SeedPodNetwork = constants.SeedPodNetworkMapped
+	if !cfg.IsHA && cfg.SeedPodNetworkV4.IsIPv4() {
+		v.SeedPodNetworkV4 = constants.SeedPodNetworkMapped
 	}
 
 	if cfg.VPNServerIndex != "" {

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/vpn2/cmd/vpn_client/app/pathcontroller"
 	"github.com/gardener/vpn2/cmd/vpn_client/app/setup"
 	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/constants"
 	"github.com/gardener/vpn2/pkg/openvpn"
 	"github.com/gardener/vpn2/pkg/pprof"
 	"github.com/gardener/vpn2/pkg/utils"
@@ -55,15 +56,16 @@ func NewCommand() *cobra.Command {
 
 func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 	v := openvpn.ClientValues{
-		Device:            "tun0",
-		IPFamily:          cfg.PrimaryIPFamily(),
-		ReversedVPNHeader: cfg.ReversedVPNHeader,
-		Endpoint:          cfg.Endpoint,
-		OpenVPNPort:       cfg.OpenVPNPort,
-		VPNClientIndex:    cfg.VPNClientIndex,
-		IsShootClient:     cfg.IsShootClient,
-		IsHA:              cfg.IsHA,
-		SeedPodNetwork:    cfg.SeedPodNetwork.String(),
+		Device:               "tun0",
+		IPFamily:             cfg.PrimaryIPFamily(),
+		ReversedVPNHeader:    cfg.ReversedVPNHeader,
+		Endpoint:             cfg.Endpoint,
+		OpenVPNPort:          cfg.OpenVPNPort,
+		VPNClientIndex:       cfg.VPNClientIndex,
+		IsShootClient:        cfg.IsShootClient,
+		IsHA:                 cfg.IsHA,
+		SeedPodNetwork:       cfg.SeedPodNetwork.String(),
+		SeedPodNetworkMapped: constants.SeedPodNetworkMapped,
 	}
 	vpnSeedServer := "vpn-seed-server"
 

--- a/cmd/vpn_client/app/pathcontroller/client_router.go
+++ b/cmd/vpn_client/app/pathcontroller/client_router.go
@@ -12,10 +12,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/vpn2/pkg/network"
-	"github.com/gardener/vpn2/pkg/shoot_client/tunnel"
 	"github.com/go-logr/logr"
 	"github.com/vishvananda/netlink"
+
+	"github.com/gardener/vpn2/pkg/network"
+	"github.com/gardener/vpn2/pkg/shoot_client/tunnel"
 )
 
 type clientRouter struct {

--- a/cmd/vpn_client/app/pathcontroller/pathcontroller.go
+++ b/cmd/vpn_client/app/pathcontroller/pathcontroller.go
@@ -11,11 +11,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/network"
 	"github.com/gardener/vpn2/pkg/utils"
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
 )
 
 const Name = "path-controller"

--- a/cmd/vpn_client/app/pathcontroller/ping.go
+++ b/cmd/vpn_client/app/pathcontroller/ping.go
@@ -14,11 +14,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gardener/vpn2/pkg/constants"
-	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv6"
+
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
 )
 
 type icmpPinger struct {

--- a/cmd/vpn_client/app/setup/setup.go
+++ b/cmd/vpn_client/app/setup/setup.go
@@ -7,11 +7,12 @@ package setup
 import (
 	"context"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/utils"
 	"github.com/gardener/vpn2/pkg/vpn_client"
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
 )
 
 const Name = "setup"

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -72,7 +72,7 @@ func run(_ context.Context, log logr.Logger) error {
 	}
 
 	if !cfg.IsHA {
-		log.Info("setting up iptables rules for Envoy")
+		log.Info("setting up double NAT IPv4 iptables rules")
 		ipTable, err := network.NewIPTables(log, iptables.ProtocolIPv4)
 		if err != nil {
 			return err
@@ -102,7 +102,6 @@ func run(_ context.Context, log logr.Logger) error {
 				}
 			}
 		}
-
 	}
 
 	log.Info("writing openvpn config file", "values", v)

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -79,7 +79,7 @@ func run(_ context.Context, log logr.Logger) error {
 
 		for _, nw := range cfg.PodNetworks {
 			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", "65532", "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
 				if err != nil {
 					return err
 				}
@@ -87,7 +87,7 @@ func run(_ context.Context, log logr.Logger) error {
 		}
 		for _, nw := range cfg.ServiceNetworks {
 			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", "65532", "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
+				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
 				if err != nil {
 					return err
 				}
@@ -95,7 +95,7 @@ func run(_ context.Context, log logr.Logger) error {
 		}
 		for _, nw := range cfg.NodeNetworks {
 			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", "65532", "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
 				if err != nil {
 					return err
 				}

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -78,28 +78,35 @@ func run(_ context.Context, log logr.Logger) error {
 			return err
 		}
 
-		for _, nw := range cfg.PodNetworks {
-			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
-				if err != nil {
-					return err
-				}
+		ipv4PodNetworks := network.GetByIPFamily(cfg.PodNetworks, network.IPv4Family)
+		if len(ipv4PodNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 pod network is supported. v4 pod networks: %s", ipv4PodNetworks)
+		}
+		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ServiceNetworks, network.IPv4Family)
+		if len(ipv4ServiceNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 service network is supported. v4 service networks: %s", ipv4ServiceNetworks)
+		}
+		ipv4NodeNetworks := network.GetByIPFamily(cfg.NodeNetworks, network.IPv4Family)
+		if len(ipv4NodeNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 node network is supported. v4 node networks: %s", ipv4NodeNetworks)
+		}
+
+		for _, nw := range ipv4PodNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+			if err != nil {
+				return err
 			}
 		}
-		for _, nw := range cfg.ServiceNetworks {
-			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
-				if err != nil {
-					return err
-				}
+		for _, nw := range ipv4ServiceNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
+			if err != nil {
+				return err
 			}
 		}
-		for _, nw := range cfg.NodeNetworks {
-			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
-				if err != nil {
-					return err
-				}
+		for _, nw := range ipv4NodeNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -9,6 +9,10 @@ import (
 	"fmt"
 
 	"github.com/coreos/go-iptables/iptables"
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"k8s.io/component-base/version/verflag"
+
 	"github.com/gardener/vpn2/cmd/vpn_server/app/setup"
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
@@ -17,9 +21,6 @@ import (
 	"github.com/gardener/vpn2/pkg/pprof"
 	"github.com/gardener/vpn2/pkg/utils"
 	"github.com/gardener/vpn2/pkg/vpn_server"
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
-	"k8s.io/component-base/version/verflag"
 )
 
 // Name is a const for the name of this component.

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -88,7 +88,7 @@ func run(_ context.Context, log logr.Logger) error {
 		}
 		for _, nw := range cfg.ServiceNetworks {
 			if nw.IsIPv4() {
-				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
+				err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
 				if err != nil {
 					return err
 				}

--- a/cmd/vpn_server/app/exporter.go
+++ b/cmd/vpn_server/app/exporter.go
@@ -7,11 +7,12 @@ package app
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/openvpn/exporter"
 	"github.com/gardener/vpn2/pkg/utils"
-	"github.com/go-logr/logr"
-	"github.com/spf13/cobra"
 )
 
 func exporterCommand() *cobra.Command {

--- a/cmd/vpn_server/app/firewall.go
+++ b/cmd/vpn_server/app/firewall.go
@@ -93,13 +93,15 @@ func runFirewallCommand(log logr.Logger, device, mode string, networks []string,
 		log.Info(fmt.Sprintf("iptables %s INPUT %s", opName, strings.Join(spec, " ")))
 	}
 
-	err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetwork)
-	if err != nil {
-		return err
-	}
-	err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetwork, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
-	if err != nil {
-		return err
+	if device == constants.TunnelDevice {
+		err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetwork)
+		if err != nil {
+			return err
+		}
+		err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetwork, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
+		if err != nil {
+			return err
+		}
 	}
 
 	if mode == "up" {

--- a/cmd/vpn_server/app/firewall.go
+++ b/cmd/vpn_server/app/firewall.go
@@ -45,7 +45,7 @@ func firewallCommand() *cobra.Command {
 	cmd.Flags().StringVar(&device, "device", "", "device to configure")
 	cmd.Flags().StringVar(&mode, "mode", "", "mode of firewall (up or down)")
 	cmd.Flags().StringSliceVar(&shootNetworks, "shoot-network", nil, "shoot networks to add routes for")
-	cmd.Flags().StringVar(&seedPodNetworkV4, "seed-pod-network-v4", "", "v4 seed pod network to add double-nat mapping rules for")
+	cmd.Flags().StringVar(&seedPodNetworkV4, "seed-pod-network-v4", "", "ipv4 seed pod network to add double-nat mapping rules for")
 	cmd.MarkFlagsRequiredTogether("device", "mode")
 
 	return cmd

--- a/cmd/vpn_server/app/firewall.go
+++ b/cmd/vpn_server/app/firewall.go
@@ -7,17 +7,18 @@ package app
 import (
 	"errors"
 	"fmt"
-	"github.com/gardener/vpn2/pkg/constants"
 	"net"
 	"os"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
-	"github.com/gardener/vpn2/pkg/network"
-	"github.com/gardener/vpn2/pkg/utils"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/vishvananda/netlink"
+
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
+	"github.com/gardener/vpn2/pkg/utils"
 )
 
 func firewallCommand() *cobra.Command {

--- a/cmd/vpn_server/app/setup/setup.go
+++ b/cmd/vpn_server/app/setup/setup.go
@@ -7,10 +7,11 @@ package setup
 import (
 	"context"
 
-	"github.com/gardener/vpn2/pkg/utils"
-	"github.com/gardener/vpn2/pkg/vpn_client"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
+
+	"github.com/gardener/vpn2/pkg/utils"
+	"github.com/gardener/vpn2/pkg/vpn_client"
 )
 
 const Name = "setup"

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/ahmetb/gen-crd-api-reference-docs v0.3.0/go.mod h1:TdjdkYhlOifCQWPs1UdTma97kQQMozf5h26hTuG70u8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -193,7 +192,6 @@ go.mongodb.org/mongo-driver v1.13.1 h1:YIc7HTYsKndGK4RFzJ3covLz1byri52x0IoMB0Pt/
 go.mongodb.org/mongo-driver v1.13.1/go.mod h1:wcDf1JBCXy2mOW0bWHwO/IOYqdca1MPCwDtFu/Z9+eo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
@@ -267,7 +265,6 @@ k8s.io/apimachinery v0.32.2 h1:yoQBR9ZGkA6Rgmhbp/yuT9/g+4lxtsGYwW6dR6BDPLQ=
 k8s.io/apimachinery v0.32.2/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 k8s.io/client-go v0.32.2 h1:4dYCD4Nz+9RApM2b/3BtVvBHw54QjMFUl1OLcJG5yOA=
 k8s.io/client-go v0.32.2/go.mod h1:fpZ4oJXclZ3r2nDOv+Ux3XcJutfrwjKTCHz2H3sww94=
-k8s.io/code-generator v0.32.2/go.mod h1:plh7bWk7JztAUkHM4zpbdy0KOMdrhsePcZL2HLWFH7Y=
 k8s.io/component-base v0.32.2 h1:1aUL5Vdmu7qNo4ZsE+569PV5zFatM9hl+lb3dEea2zU=
 k8s.io/component-base v0.32.2/go.mod h1:PXJ61Vx9Lg+P5mS8TLd7bCIr+eMJRQTyXe8KvkrvJq0=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
@@ -278,7 +275,6 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.20.2 h1:/439OZVxoEc02psi1h4QO3bHzTgu49bb347Xp4gW1pc=
 sigs.k8s.io/controller-runtime v0.20.2/go.mod h1:xg2XB0K5ShQzAgsoujxuKN4LNXR2LfwwHsPj7Iaw+XY=
-sigs.k8s.io/controller-tools v0.17.2/go.mod h1:4q5tZG2JniS5M5bkiXY2/potOiXyhoZVw/U48vLkXk0=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/structured-merge-diff/v4 v4.5.0 h1:nbCitCK2hfnhyiKo6uf2HxUPTCodY6Qaf85SbDIaMBk=

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/pkg/config/pathcontroller.go
+++ b/pkg/config/pathcontroller.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/caarlos0/env/v10"
-	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/vpn2/pkg/network"
 )
 
 type PathController struct {

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -74,8 +74,8 @@ func GetVPNClientConfig() (VPNClient, error) {
 		}
 	}
 
-	if len(cfg.IPFamilies) > 2 {
-		return VPNClient{}, fmt.Errorf("IP_FAMILIES must not contain more than 2 elements")
+	if len(cfg.IPFamilies) < 1 || len(cfg.IPFamilies) > 2 {
+		return VPNClient{}, fmt.Errorf("IP_FAMILIES must contain at least one but no more than 2 elements")
 	}
 
 	for _, ipFamily := range cfg.IPFamilies {

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -20,25 +20,25 @@ type VPNClient struct {
 		KeepAliveInterval int64 `env:"KEEPALIVE_INTVL" envDefault:"75"`
 		KeepAliveProbes   int64 `env:"KEEPALIVE_PROBES" envDefault:"9"`
 	} `envPrefix:"TCP_"`
-	IPFamilies          string       `env:"IP_FAMILIES" envDefault:"IPv4"`
-	Endpoint            string       `env:"ENDPOINT"`
-	OpenVPNPort         int          `env:"OPENVPN_PORT" envDefault:"8132"`
-	VPNNetwork          network.CIDR `env:"VPN_NETWORK"`
-	SeedPodNetwork      network.CIDR `env:"SEED_POD_NETWORK"`
-	ShootServiceNetwork network.CIDR `env:"SHOOT_SERVICE_NETWORK"`
-	ShootPodNetwork     network.CIDR `env:"SHOOT_POD_NETWORK"`
-	ShootNodeNetwork    network.CIDR `env:"SHOOT_NODE_NETWORK"`
-	IsShootClient       bool         `env:"IS_SHOOT_CLIENT"`
-	PodName             string       `env:"POD_NAME"`
-	Namespace           string       `env:"NAMESPACE"`
-	VPNServerIndex      string       `env:"VPN_SERVER_INDEX"`
-	VPNClientIndex      int
-	IsHA                bool          `env:"IS_HA"`
-	ReversedVPNHeader   string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
-	HAVPNClients        int           `env:"HA_VPN_CLIENTS"`
-	HAVPNServers        int           `env:"HA_VPN_SERVERS"`
-	PodLabelSelector    string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
-	WaitTime            time.Duration `env:"WAIT_TIME" envDefault:"2s"`
+	IPFamilies            string       `env:"IP_FAMILIES" envDefault:"IPv4"`
+	Endpoint              string       `env:"ENDPOINT"`
+	OpenVPNPort           int          `env:"OPENVPN_PORT" envDefault:"8132"`
+	VPNNetwork            network.CIDR `env:"VPN_NETWORK"`
+	SeedPodNetworkV4      network.CIDR `env:"SEED_POD_NETWORK_V4"`
+	ShootServiceNetworkV4 network.CIDR `env:"SHOOT_SERVICE_NETWORK_V4"`
+	ShootPodNetworkV4     network.CIDR `env:"SHOOT_POD_NETWORK_V4"`
+	ShootNodeNetworkV4    network.CIDR `env:"SHOOT_NODE_NETWORK_V4"`
+	IsShootClient         bool         `env:"IS_SHOOT_CLIENT"`
+	PodName               string       `env:"POD_NAME"`
+	Namespace             string       `env:"NAMESPACE"`
+	VPNServerIndex        string       `env:"VPN_SERVER_INDEX"`
+	VPNClientIndex        int
+	IsHA                  bool          `env:"IS_HA"`
+	ReversedVPNHeader     string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
+	HAVPNClients          int           `env:"HA_VPN_CLIENTS"`
+	HAVPNServers          int           `env:"HA_VPN_SERVERS"`
+	PodLabelSelector      string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
+	WaitTime              time.Duration `env:"WAIT_TIME" envDefault:"2s"`
 }
 
 func (v VPNClient) PrimaryIPFamily() string {

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v10"
+
 	"github.com/gardener/vpn2/pkg/network"
 )
 

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -80,7 +80,7 @@ func GetVPNClientConfig() (VPNClient, error) {
 
 	for _, ipFamily := range cfg.IPFamilies {
 		if ipFamily != network.IPv4Family && ipFamily != constants.IPv6Family {
-			return VPNClient{}, fmt.Errorf("IP_FAMILIES must only contain %s and %s", network.IPv4Family, constants.IPv6Family)
+			return VPNClient{}, fmt.Errorf("IP_FAMILIES can only contain %s or %s, found value %q", network.IPv4Family, constants.IPv6Family, ipFamily)
 		}
 	}
 

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -19,22 +19,25 @@ type VPNClient struct {
 		KeepAliveInterval int64 `env:"KEEPALIVE_INTVL" envDefault:"75"`
 		KeepAliveProbes   int64 `env:"KEEPALIVE_PROBES" envDefault:"9"`
 	} `envPrefix:"TCP_"`
-	IPFamilies        string       `env:"IP_FAMILIES" envDefault:"IPv4"`
-	Endpoint          string       `env:"ENDPOINT"`
-	OpenVPNPort       int          `env:"OPENVPN_PORT" envDefault:"8132"`
-	VPNNetwork        network.CIDR `env:"VPN_NETWORK"`
-	SeedPodNetwork    network.CIDR `env:"SEED_POD_NETWORK"`
-	IsShootClient     bool         `env:"IS_SHOOT_CLIENT"`
-	PodName           string       `env:"POD_NAME"`
-	Namespace         string       `env:"NAMESPACE"`
-	VPNServerIndex    string       `env:"VPN_SERVER_INDEX"`
-	VPNClientIndex    int
-	IsHA              bool          `env:"IS_HA"`
-	ReversedVPNHeader string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
-	HAVPNClients      int           `env:"HA_VPN_CLIENTS"`
-	HAVPNServers      int           `env:"HA_VPN_SERVERS"`
-	PodLabelSelector  string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
-	WaitTime          time.Duration `env:"WAIT_TIME" envDefault:"2s"`
+	IPFamilies          string       `env:"IP_FAMILIES" envDefault:"IPv4"`
+	Endpoint            string       `env:"ENDPOINT"`
+	OpenVPNPort         int          `env:"OPENVPN_PORT" envDefault:"8132"`
+	VPNNetwork          network.CIDR `env:"VPN_NETWORK"`
+	SeedPodNetwork      network.CIDR `env:"SEED_POD_NETWORK"`
+	ShootServiceNetwork network.CIDR `env:"SHOOT_SERVICE_NETWORK"`
+	ShootPodNetwork     network.CIDR `env:"SHOOT_POD_NETWORK"`
+	ShootNodeNetwork    network.CIDR `env:"SHOOT_NODE_NETWORK"`
+	IsShootClient       bool         `env:"IS_SHOOT_CLIENT"`
+	PodName             string       `env:"POD_NAME"`
+	Namespace           string       `env:"NAMESPACE"`
+	VPNServerIndex      string       `env:"VPN_SERVER_INDEX"`
+	VPNClientIndex      int
+	IsHA                bool          `env:"IS_HA"`
+	ReversedVPNHeader   string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
+	HAVPNClients        int           `env:"HA_VPN_CLIENTS"`
+	HAVPNServers        int           `env:"HA_VPN_SERVERS"`
+	PodLabelSelector    string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
+	WaitTime            time.Duration `env:"WAIT_TIME" envDefault:"2s"`
 }
 
 func (v VPNClient) PrimaryIPFamily() string {

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -5,44 +5,47 @@
 package config
 
 import (
+	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/caarlos0/env/v10"
 
+	"github.com/gardener/vpn2/pkg/constants"
 	"github.com/gardener/vpn2/pkg/network"
 )
 
 type VPNClient struct {
 	TCP struct {
-		KeepAliveTime     int64 `env:"KEEPALIVE_TIME" envDefault:"7200"`
-		KeepAliveInterval int64 `env:"KEEPALIVE_INTVL" envDefault:"75"`
-		KeepAliveProbes   int64 `env:"KEEPALIVE_PROBES" envDefault:"9"`
+		KeepAliveTime     uint64 `env:"KEEPALIVE_TIME" envDefault:"7200"`
+		KeepAliveInterval uint64 `env:"KEEPALIVE_INTVL" envDefault:"75"`
+		KeepAliveProbes   uint64 `env:"KEEPALIVE_PROBES" envDefault:"9"`
 	} `envPrefix:"TCP_"`
-	IPFamilies            string       `env:"IP_FAMILIES" envDefault:"IPv4"`
-	Endpoint              string       `env:"ENDPOINT"`
-	OpenVPNPort           int          `env:"OPENVPN_PORT" envDefault:"8132"`
-	VPNNetwork            network.CIDR `env:"VPN_NETWORK"`
-	SeedPodNetworkV4      network.CIDR `env:"SEED_POD_NETWORK_V4"`
-	ShootServiceNetworkV4 network.CIDR `env:"SHOOT_SERVICE_NETWORK_V4"`
-	ShootPodNetworkV4     network.CIDR `env:"SHOOT_POD_NETWORK_V4"`
-	ShootNodeNetworkV4    network.CIDR `env:"SHOOT_NODE_NETWORK_V4"`
-	IsShootClient         bool         `env:"IS_SHOOT_CLIENT"`
-	PodName               string       `env:"POD_NAME"`
-	Namespace             string       `env:"NAMESPACE"`
-	VPNServerIndex        string       `env:"VPN_SERVER_INDEX"`
-	VPNClientIndex        int
-	IsHA                  bool          `env:"IS_HA"`
-	ReversedVPNHeader     string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
-	HAVPNClients          int           `env:"HA_VPN_CLIENTS"`
-	HAVPNServers          int           `env:"HA_VPN_SERVERS"`
-	PodLabelSelector      string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
-	WaitTime              time.Duration `env:"WAIT_TIME" envDefault:"2s"`
+	IPFamilies           []string       `env:"IP_FAMILIES" envDefault:"IPv4"`
+	Endpoint             string         `env:"ENDPOINT"`
+	OpenVPNPort          uint           `env:"OPENVPN_PORT" envDefault:"8132"`
+	VPNNetwork           network.CIDR   `env:"VPN_NETWORK"`
+	SeedPodNetworkV4     network.CIDR   `env:"SEED_POD_NETWORK_V4"`
+	ShootServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS"`
+	ShootPodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS"`
+	ShootNodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`
+	IsShootClient        bool           `env:"IS_SHOOT_CLIENT"`
+	PodName              string         `env:"POD_NAME"`
+	Namespace            string         `env:"NAMESPACE"`
+	VPNServerIndex       string         `env:"VPN_SERVER_INDEX"`
+	VPNClientIndex       int
+	IsHA                 bool          `env:"IS_HA"`
+	ReversedVPNHeader    string        `env:"REVERSED_VPN_HEADER" envDefault:"invalid-host"`
+	HAVPNClients         uint          `env:"HA_VPN_CLIENTS"`
+	HAVPNServers         uint          `env:"HA_VPN_SERVERS"`
+	PodLabelSelector     string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
+	WaitTime             time.Duration `env:"WAIT_TIME" envDefault:"2s"`
 }
 
 func (v VPNClient) PrimaryIPFamily() string {
-	return strings.Split(v.IPFamilies, ",")[0]
+	return v.IPFamilies[0]
 }
 
 func GetVPNClientConfig() (VPNClient, error) {
@@ -61,6 +64,34 @@ func GetVPNClientConfig() (VPNClient, error) {
 		return VPNClient{}, err
 	}
 	cfg.VPNClientIndex = -1
+
+	if cfg.IsHA {
+		if cfg.PodName == "" {
+			return VPNClient{}, fmt.Errorf("IS_HA is set to true but POD_NAME is not set")
+		}
+		if cfg.VPNServerIndex == "" {
+			return VPNClient{}, fmt.Errorf("IS_HA is set to true but VPN_SERVER_INDEX is not set")
+		}
+	}
+
+	if len(cfg.IPFamilies) > 2 {
+		return VPNClient{}, fmt.Errorf("IP_FAMILIES must not contain more than 2 elements")
+	}
+
+	for _, ipFamily := range cfg.IPFamilies {
+		if ipFamily != network.IPv4Family && ipFamily != constants.IPv6Family {
+			return VPNClient{}, fmt.Errorf("IP_FAMILIES must only contain %s and %s", network.IPv4Family, constants.IPv6Family)
+		}
+	}
+
+	// Remove ip family duplicates
+	slices.Sort(cfg.IPFamilies)
+	cfg.IPFamilies = slices.Compact(cfg.IPFamilies)
+
+	if cfg.WaitTime < 0 {
+		return VPNClient{}, fmt.Errorf("WAIT_TIME must not be negative")
+	}
+
 	if cfg.PodName != "" {
 		podNameSlice := strings.Split(cfg.PodName, "-")
 		clientIndex, err := strconv.Atoi(podNameSlice[len(podNameSlice)-1])

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -3,7 +3,6 @@ package config_test
 import (
 	"maps"
 	"os"
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,11 +14,6 @@ import (
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/network"
 )
-
-func TestVPNClient(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "VPNClient Suite")
-}
 
 var _ = Describe("GetVPNClientConfig", func() {
 	var (

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -1,0 +1,333 @@
+package config_test
+
+import (
+	"maps"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/network"
+)
+
+func TestVPNClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VPNClient Suite")
+}
+
+var _ = Describe("GetVPNClientConfig", func() {
+	var (
+		defaultEnvVars map[string]string
+	)
+
+	BeforeEach(func() {
+		// Set default environment variables
+		defaultEnvVars = map[string]string{
+			"TCP_KEEPALIVE_TIME":     "7200",
+			"TCP_KEEPALIVE_INTVL":    "75",
+			"TCP_KEEPALIVE_PROBES":   "9",
+			"IP_FAMILIES":            "IPv4",
+			"ENDPOINT":               "endpoint",
+			"OPENVPN_PORT":           "8132",
+			"VPN_NETWORK":            "fd8f:6d53:b97a:1::/96",
+			"SEED_POD_NETWORK_V4":    "10.0.0.0/8",
+			"SHOOT_SERVICE_NETWORKS": "100.64.0.0/13",
+			"SHOOT_POD_NETWORKS":     "100.96.0.0/11",
+			"SHOOT_NODE_NETWORKS":    "100.128.0.0/10",
+			"IS_SHOOT_CLIENT":        "true",
+			"POD_NAME":               "test-pod-1",
+			"NAMESPACE":              "test-namespace",
+			"VPN_SERVER_INDEX":       "1",
+			"IS_HA":                  "true",
+			"REVERSED_VPN_HEADER":    "invalid-host",
+			"HA_VPN_CLIENTS":         "3",
+			"HA_VPN_SERVERS":         "3",
+			"POD_LABEL_SELECTOR":     "app=kubernetes,role=apiserver",
+			"WAIT_TIME":              "2s",
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up environment variables after each test
+		Expect(os.Unsetenv("TCP_KEEPALIVE_TIME")).To(Succeed())
+		Expect(os.Unsetenv("TCP_KEEPALIVE_INTVL")).To(Succeed())
+		Expect(os.Unsetenv("TCP_KEEPALIVE_PROBES")).To(Succeed())
+		Expect(os.Unsetenv("IP_FAMILIES")).To(Succeed())
+		Expect(os.Unsetenv("ENDPOINT")).To(Succeed())
+		Expect(os.Unsetenv("OPENVPN_PORT")).To(Succeed())
+		Expect(os.Unsetenv("VPN_NETWORK")).To(Succeed())
+		Expect(os.Unsetenv("SEED_POD_NETWORK_V4")).To(Succeed())
+		Expect(os.Unsetenv("SHOOT_SERVICE_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("SHOOT_POD_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("SHOOT_NODE_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("IS_SHOOT_CLIENT")).To(Succeed())
+		Expect(os.Unsetenv("POD_NAME")).To(Succeed())
+		Expect(os.Unsetenv("NAMESPACE")).To(Succeed())
+		Expect(os.Unsetenv("VPN_SERVER_INDEX")).To(Succeed())
+		Expect(os.Unsetenv("IS_HA")).To(Succeed())
+		Expect(os.Unsetenv("REVERSED_VPN_HEADER")).To(Succeed())
+		Expect(os.Unsetenv("HA_VPN_CLIENTS")).To(Succeed())
+		Expect(os.Unsetenv("HA_VPN_SERVERS")).To(Succeed())
+		Expect(os.Unsetenv("POD_LABEL_SELECTOR")).To(Succeed())
+		Expect(os.Unsetenv("WAIT_TIME")).To(Succeed())
+	})
+
+	type testCase struct {
+		envVars         map[string]string
+		expectedMatcher types.GomegaMatcher
+		expectedError   bool
+	}
+
+	DescribeTable("should parse the configuration correctly",
+		func(tc testCase) {
+
+			// Merge default and test environment variables
+			envVars := maps.Clone(defaultEnvVars)
+			maps.Copy(envVars, tc.envVars)
+
+			// Set environment variables for the test
+			for key, value := range envVars {
+				Expect(os.Setenv(key, value)).To(Succeed())
+			}
+
+			// Call the function
+			cfg, err := config.GetVPNClientConfig()
+
+			if tc.expectedError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+			if tc.expectedMatcher != nil {
+				Expect(cfg).To(tc.expectedMatcher)
+			}
+		},
+		Entry("default configuration", testCase{
+			envVars:       defaultEnvVars,
+			expectedError: false,
+		}),
+		Entry("invalid HA configuration should fail", testCase{
+			envVars: map[string]string{
+				"IS_HA":            "banana",
+				"VPN_SERVER_INDEX": "",
+				"POD_NAME":         "",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if POD_NAME is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":            "true",
+				"VPN_SERVER_INDEX": "1",
+				"POD_NAME":         "",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if VPN_SERVER_INDEX is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":            "true",
+				"VPN_SERVER_INDEX": "",
+				"POD_NAME":         "test-pod-1",
+			},
+			expectedError: true,
+		}),
+		Entry("non-HA configuration should not require VPN_SERVER_INDEX", testCase{
+			envVars: map[string]string{
+				"IS_HA":            "false",
+				"VPN_SERVER_INDEX": "",
+			},
+			expectedError: false,
+		}),
+		Entry("non-HA configuration with random pod name should yield VPNClientIndex of -1", testCase{
+			envVars: map[string]string{
+				"IS_HA":    "false",
+				"POD_NAME": "test-pod-6f7c79b87f-kpqcl",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"VPNClientIndex": Equal(-1)}),
+		}),
+		Entry("HA configuration with non-random pod name should yield correct VPNClientIndex", testCase{
+			envVars: map[string]string{
+				"POD_NAME": "test-pod-2",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"VPNClientIndex": Equal(2)}),
+		}),
+		Entry("empty TCP config should yield default values", testCase{
+			envVars: map[string]string{
+				"TCP_KEEPALIVE_TIME":   "",
+				"TCP_KEEPALIVE_INTVL":  "",
+				"TCP_KEEPALIVE_PROBES": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"TCP": MatchFields(IgnoreExtras, Fields{
+					"KeepAliveTime":     Equal(uint64(7200)),
+					"KeepAliveInterval": Equal(uint64(75)),
+					"KeepAliveProbes":   Equal(uint64(9)),
+				}),
+			}),
+		}),
+		Entry("bad TCP config should fail", testCase{
+			envVars: map[string]string{
+				"TCP_KEEPALIVE_TIME":   "potato",
+				"TCP_KEEPALIVE_INTVL":  "banana",
+				"TCP_KEEPALIVE_PROBES": "apple",
+			},
+			expectedError: true,
+		}),
+		Entry("negative TCP config values should fail", testCase{
+			envVars: map[string]string{
+				"TCP_KEEPALIVE_TIME":   "-100",
+				"TCP_KEEPALIVE_INTVL":  "-10",
+				"TCP_KEEPALIVE_PROBES": "-30",
+			},
+			expectedError: true,
+		}),
+		Entry("empty IP_FAMILIES should yield IPv4 default", testCase{
+			envVars: map[string]string{
+				"IP_FAMILIES": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"IPFamilies": ContainElement("IPv4")}),
+		}),
+		Entry("IP_FAMILIES with more than two entries should fail", testCase{
+			envVars: map[string]string{
+				"IP_FAMILIES": "IPv4,IPv6,IPv4",
+			},
+			expectedError: true,
+		}),
+		Entry("IP_FAMILIES with values other than IPv4 or IPv6 should fail", testCase{
+			envVars: map[string]string{
+				"IP_FAMILIES": "IPv4,IPv7",
+			},
+			expectedError: true,
+		}),
+		Entry("IP_FAMILIES with duplicate values are ignored", testCase{
+			envVars: map[string]string{
+				"IP_FAMILIES": "IPv4,IPv4",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"IPFamilies": ConsistOf("IPv4")}),
+		}),
+		Entry("negative OPENVPN_PORT value should fail", testCase{
+			envVars: map[string]string{
+				"OPENVPN_PORT": "-1234",
+			},
+			expectedError: true,
+		}),
+		Entry("non-number OPENVPN_PORT value should fail", testCase{
+			envVars: map[string]string{
+				"OPENVPN_PORT": "banana",
+			},
+			expectedError: true,
+		}),
+		Entry("non-CIDR VPN_NETWORK value should fail", testCase{
+			envVars: map[string]string{
+				"VPN_NETWORK": "banana",
+			},
+			expectedError: true,
+		}),
+		Entry("missing VPN_NETWORK value should yield default", testCase{
+			envVars: map[string]string{
+				"VPN_NETWORK": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"VPNNetwork": Equal(network.ParseIPNetIgnoreError(constants.DefaultVPNRangeV6))}),
+		}),
+		Entry("multiple vpn networks should fail", testCase{
+			envVars: map[string]string{
+				"VPN_NETWORK": "fd8f:6d53:b97a:1::/96,fd8f:6d53:b97a:2::/96",
+			},
+			expectedError: true,
+		}),
+		Entry("multiple seed pod networks should fail", testCase{
+			envVars: map[string]string{
+				"SEED_POD_NETWORK_V4": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
+			},
+			expectedError: true,
+		}),
+		Entry("multiple pod networks", testCase{
+			envVars: map[string]string{
+				"SHOOT_POD_NETWORKS": "100.96.0.0/11,100.97.0.0/11,100.98.0.0/11",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"ShootPodNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.96.0.0/11"),
+					network.ParseIPNetIgnoreError("100.97.0.0/11"),
+					network.ParseIPNetIgnoreError("100.98.0.0/11")),
+			}),
+		}),
+		Entry("multiple service networks", testCase{
+			envVars: map[string]string{
+				"SHOOT_SERVICE_NETWORKS": "100.96.0.0/11,100.97.0.0/11,100.98.0.0/11",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"ShootServiceNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.96.0.0/11"),
+					network.ParseIPNetIgnoreError("100.97.0.0/11"),
+					network.ParseIPNetIgnoreError("100.98.0.0/11")),
+			}),
+		}),
+		Entry("multiple node networks", testCase{
+			envVars: map[string]string{
+				"SHOOT_NODE_NETWORKS": "100.96.0.0/11,100.97.0.0/11,100.98.0.0/11",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"ShootNodeNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.96.0.0/11"),
+					network.ParseIPNetIgnoreError("100.97.0.0/11"),
+					network.ParseIPNetIgnoreError("100.98.0.0/11")),
+			}),
+		}),
+		Entry("non-boolean IS_SHOOT_CLIENT value should fail", testCase{
+			envVars: map[string]string{
+				"IS_SHOOT_CLIENT": "banana",
+			},
+			expectedError: true,
+		}),
+		Entry("non-number HA_VPN_CLIENTS value should fail", testCase{
+			envVars: map[string]string{
+				"HA_VPN_CLIENTS": "banana",
+			},
+			expectedError: true,
+		}),
+		Entry("negative HA_VPN_CLIENTS value should fail", testCase{
+			envVars: map[string]string{
+				"HA_VPN_CLIENTS": "-1",
+			},
+			expectedError: true,
+		}),
+		Entry("non-number HA_VPN_SERVERS value should fail", testCase{
+			envVars: map[string]string{
+				"HA_VPN_SERVERS": "banana",
+			},
+			expectedError: true,
+		}),
+		Entry("negative HA_VPN_SERVERS value should fail", testCase{
+			envVars: map[string]string{
+				"HA_VPN_SERVERS": "-1",
+			},
+			expectedError: true,
+		}),
+		Entry("negative WAIT_TIME value should fail", testCase{
+			envVars: map[string]string{
+				"WAIT_TIME": "-1s",
+			},
+			expectedError: true,
+		}),
+		Entry("missing WAIT_TIME value should yield the default", testCase{
+			envVars: map[string]string{
+				"WAIT_TIME": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"WaitTime": Equal(2 * time.Second)}),
+		}),
+		Entry("missing POD_LABEL_SELECTOR value should yield the default", testCase{
+			envVars: map[string]string{
+				"POD_LABEL_SELECTOR": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{"PodLabelSelector": Equal("app=kubernetes,role=apiserver")}),
+		}),
+	)
+})

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/network"
 )

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -12,16 +12,16 @@ import (
 )
 
 type VPNServer struct {
-	ServiceNetworks []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
-	PodNetworks     []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
-	NodeNetworks    []network.CIDR `env:"NODE_NETWORKS"`
-	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
-	SeedPodNetwork  network.CIDR   `env:"SEED_POD_NETWORK"`
-	PodName         string         `env:"POD_NAME"`
-	StatusPath      string         `env:"OPENVPN_STATUS_PATH"`
-	IsHA            bool           `env:"IS_HA"`
-	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
-	LocalNodeIP     string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
+	ServiceNetworks  []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
+	PodNetworks      []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
+	NodeNetworks     []network.CIDR `env:"NODE_NETWORKS"`
+	VPNNetwork       network.CIDR   `env:"VPN_NETWORK"`
+	SeedPodNetworkV4 network.CIDR   `env:"SEED_POD_NETWORK_V4"`
+	PodName          string         `env:"POD_NAME"`
+	StatusPath       string         `env:"OPENVPN_STATUS_PATH"`
+	IsHA             bool           `env:"IS_HA"`
+	HAVPNClients     int            `env:"HA_VPN_CLIENTS"`
+	LocalNodeIP      string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -6,8 +6,9 @@ package config
 
 import (
 	"github.com/caarlos0/env/v10"
-	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/vpn2/pkg/network"
 )
 
 type VPNServer struct {

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/caarlos0/env/v10"
 	"github.com/go-logr/logr"
 
@@ -39,6 +41,19 @@ func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {
 	if err := validateVPNNetworkCIDR(cfg.VPNNetwork); err != nil {
 		return VPNServer{}, err
 	}
+
+	if cfg.IsHA {
+		if cfg.PodName == "" {
+			return VPNServer{}, fmt.Errorf("IS_HA is set to true but POD_NAME is not set")
+		}
+		if cfg.HAVPNClients <= 0 {
+			return VPNServer{}, fmt.Errorf("IS_HA is set to true but HA_VPN_CLIENTS is not set or invalid")
+		}
+		if cfg.StatusPath == "" {
+			return VPNServer{}, fmt.Errorf("IS_HA is set to true but OPENVPN_STATUS_PATH is not set")
+		}
+	}
+
 	log.Info("config parsed", "config", cfg)
 	return cfg, nil
 }

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -15,6 +15,7 @@ type VPNServer struct {
 	PodNetworks     []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
 	NodeNetworks    []network.CIDR `env:"NODE_NETWORKS"`
 	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
+	SeedPodNetwork  network.CIDR   `env:"SEED_POD_NETWORK"`
 	PodName         string         `env:"POD_NAME"`
 	StatusPath      string         `env:"OPENVPN_STATUS_PATH"`
 	IsHA            bool           `env:"IS_HA"`

--- a/pkg/config/vpn-server_test.go
+++ b/pkg/config/vpn-server_test.go
@@ -1,0 +1,214 @@
+package config_test
+
+import (
+	"maps"
+	"os"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+
+	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/network"
+)
+
+func TestVPNServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VPNServer Suite")
+}
+
+var _ = Describe("GetVPNServerConfig", func() {
+	var (
+		logger         logr.Logger
+		defaultEnvVars map[string]string
+	)
+
+	BeforeEach(func() {
+		// Create a logger
+		logger = funcr.New(func(prefix, args string) {
+			GinkgoT().Logf("%s: %s", prefix, args)
+		}, funcr.Options{})
+
+		// Set default environment variables
+		defaultEnvVars = map[string]string{
+			"SERVICE_NETWORKS":    "100.64.0.0/13",
+			"POD_NETWORKS":        "100.96.0.0/11",
+			"NODE_NETWORKS":       "100.128.0.0/10",
+			"VPN_NETWORK":         "fd8f:6d53:b97a:1::/96",
+			"SEED_POD_NETWORK_V4": "10.0.0.0/8",
+			"POD_NAME":            "test-pod",
+			"OPENVPN_STATUS_PATH": "/status",
+			"IS_HA":               "true",
+			"HA_VPN_CLIENTS":      "3",
+			"LOCAL_NODE_IP":       "192.168.1.1",
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up environment variables after each test
+		Expect(os.Unsetenv("SERVICE_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("POD_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("NODE_NETWORKS")).To(Succeed())
+		Expect(os.Unsetenv("VPN_NETWORK")).To(Succeed())
+		Expect(os.Unsetenv("SEED_POD_NETWORK_V4")).To(Succeed())
+		Expect(os.Unsetenv("POD_NAME")).To(Succeed())
+		Expect(os.Unsetenv("OPENVPN_STATUS_PATH")).To(Succeed())
+		Expect(os.Unsetenv("IS_HA")).To(Succeed())
+		Expect(os.Unsetenv("HA_VPN_CLIENTS")).To(Succeed())
+		Expect(os.Unsetenv("LOCAL_NODE_IP")).To(Succeed())
+	})
+
+	type testCase struct {
+		envVars         map[string]string
+		expectedMatcher types.GomegaMatcher
+		expectedError   bool
+	}
+
+	DescribeTable("should parse the configuration correctly",
+		func(tc testCase) {
+
+			// Merge default and test environment variables
+			envVars := maps.Clone(defaultEnvVars)
+			maps.Copy(envVars, tc.envVars)
+
+			// Set environment variables for the test
+			for key, value := range envVars {
+				Expect(os.Setenv(key, value)).To(Succeed())
+			}
+
+			// Call the function
+			cfg, err := config.GetVPNServerConfig(logger)
+
+			if tc.expectedError {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+			if tc.expectedMatcher != nil {
+				Expect(cfg).To(tc.expectedMatcher)
+			}
+		},
+		Entry("default configuration", testCase{
+			envVars:       defaultEnvVars,
+			expectedError: false,
+		}),
+		Entry("invalid HA configuration should fail", testCase{
+			envVars: map[string]string{
+				"IS_HA":               "banana",
+				"HA_VPN_CLIENTS":      "-3",
+				"POD_NAME":            "",
+				"OPENVPN_STATUS_PATH": "",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if HA_VPN_CLIENTS is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":               "true",
+				"HA_VPN_CLIENTS":      "",
+				"POD_NAME":            "test-pod",
+				"OPENVPN_STATUS_PATH": "/status",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if HA_VPN_CLIENTS is negative", testCase{
+			envVars: map[string]string{
+				"IS_HA":               "true",
+				"HA_VPN_CLIENTS":      "-3",
+				"POD_NAME":            "test-pod",
+				"OPENVPN_STATUS_PATH": "/status",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if POD_NAME is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":               "true",
+				"HA_VPN_CLIENTS":      "3",
+				"POD_NAME":            "",
+				"OPENVPN_STATUS_PATH": "/status",
+			},
+			expectedError: true,
+		}),
+		Entry("HA configuration should fail if OPENVPN_STATUS_PATH is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":               "true",
+				"HA_VPN_CLIENTS":      "3",
+				"POD_NAME":            "test-pod",
+				"OPENVPN_STATUS_PATH": "",
+			},
+			expectedError: true,
+		}),
+		Entry("missing VPN_NETWORK should yield default", testCase{
+			envVars: map[string]string{
+				"VPN_NETWORK": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"VPNNetwork": Equal(network.ParseIPNetIgnoreError(constants.DefaultVPNRangeV6)),
+			}),
+		}),
+		Entry("missing LOCAL_NODE_IP should yield env default", testCase{
+			envVars: map[string]string{
+				"LOCAL_NODE_IP": "",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"LocalNodeIP": Equal("255.255.255.255"),
+			}),
+		}),
+		Entry("multiple pod networks with spaces should fail", testCase{
+			envVars: map[string]string{
+				"POD_NETWORKS": "100.96.0.0/11, 100.97.0.0/11 , 100.98.0.0/11",
+			},
+			expectedError: true,
+		}),
+		Entry("multiple pod networks", testCase{
+			envVars: map[string]string{
+				"POD_NETWORKS": "100.96.0.0/11,100.97.0.0/11,100.98.0.0/11",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"PodNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.96.0.0/11"),
+					network.ParseIPNetIgnoreError("100.97.0.0/11"),
+					network.ParseIPNetIgnoreError("100.98.0.0/11")),
+			}),
+		}),
+		Entry("multiple service networks", testCase{
+			envVars: map[string]string{
+				"SERVICE_NETWORKS": "100.64.0.0/13,100.65.0.0/13,100.66.0.0/13",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"ServiceNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.64.0.0/13"),
+					network.ParseIPNetIgnoreError("100.65.0.0/13"),
+					network.ParseIPNetIgnoreError("100.66.0.0/13")),
+			}),
+		}),
+		Entry("multiple node networks", testCase{
+			envVars: map[string]string{
+				"NODE_NETWORKS": "100.128.0.0/10,101.128.0.0/10,102.128.0.0/10",
+			},
+			expectedMatcher: MatchFields(IgnoreExtras, Fields{
+				"NodeNetworks": ConsistOf(
+					network.ParseIPNetIgnoreError("100.128.0.0/10"),
+					network.ParseIPNetIgnoreError("101.128.0.0/10"),
+					network.ParseIPNetIgnoreError("102.128.0.0/10")),
+			}),
+		}),
+		Entry("multiple seed pod networks should fail", testCase{
+			envVars: map[string]string{
+				"SEED_POD_NETWORK_V4": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
+			},
+			expectedError: true,
+		}),
+		Entry("multiple vpn networks should fail", testCase{
+			envVars: map[string]string{
+				"VPN_NETWORK": "fd8f:6d53:b97a:1::/96,fd8f:6d53:b97a:2::/96",
+			},
+			expectedError: true,
+		}),
+	)
+})

--- a/pkg/config/vpn-server_test.go
+++ b/pkg/config/vpn-server_test.go
@@ -3,7 +3,6 @@ package config_test
 import (
 	"maps"
 	"os"
-	"testing"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/go-logr/logr"
@@ -16,11 +15,6 @@ import (
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/network"
 )
-
-func TestVPNServer(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "VPNServer Suite")
-}
 
 var _ = Describe("GetVPNServerConfig", func() {
 	var (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,6 +18,12 @@ const (
 	BondDevice = "bond0"
 	// VPNNetworkPrefixSize is the required prefix size for the VPN network.
 	VPNNetworkMask = 96
+
+	//TODO: move to gardener
+	ShootPodNetworkMapped  = "244.0.0.0/8"
+	ShootSvcNetworkMapped  = "243.0.0.0/8"
+	ShootNodeNetworkMapped = "242.0.0.0/8"
+	SeedPodNetworkMapped   = "241.0.0.0/8"
 )
 
 // DefaultVPNNetwork is the default IPv6 transfer network used by VPN.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,10 +16,14 @@ const (
 
 	// BondDevice is the name of the bond device used for the HA deployment.
 	BondDevice = "bond0"
-	// VPNNetworkPrefixSize is the required prefix size for the VPN network.
+	// TapDevice is the name of the tap device used for the HA VPN.
+	TapDevice = "tap0"
+	// TunnelDevice is the name of the tunnel device used for non-HA VPN.
+	TunnelDevice = "tun0"
+	// VPNNetworkMask is the required prefix size for the VPN network.
 	VPNNetworkMask = 96
 
-	//TODO: move to gardener
+	//TODO: use v1beta1constants.ReservedxxxMappedRange after Gardener is updated
 	ShootPodNetworkMapped  = "244.0.0.0/8"
 	ShootSvcNetworkMapped  = "243.0.0.0/8"
 	ShootNodeNetworkMapped = "242.0.0.0/8"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,10 +24,10 @@ const (
 	VPNNetworkMask = 96
 
 	//TODO: use v1beta1constants.ReservedxxxMappedRange after Gardener is updated
-	ShootPodNetworkMapped  = "244.0.0.0/8"
-	ShootSvcNetworkMapped  = "243.0.0.0/8"
-	ShootNodeNetworkMapped = "242.0.0.0/8"
-	SeedPodNetworkMapped   = "241.0.0.0/8"
+	ShootPodNetworkMapped     = "244.0.0.0/8"
+	ShootServiceNetworkMapped = "243.0.0.0/8"
+	ShootNodeNetworkMapped    = "242.0.0.0/8"
+	SeedPodNetworkMapped      = "241.0.0.0/8"
 
 	EnvoyNonRootUserId = "65532"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,6 +28,8 @@ const (
 	ShootSvcNetworkMapped  = "243.0.0.0/8"
 	ShootNodeNetworkMapped = "242.0.0.0/8"
 	SeedPodNetworkMapped   = "241.0.0.0/8"
+
+	EnvoyNonRootUserId = "65532"
 )
 
 // DefaultVPNNetwork is the default IPv6 transfer network used by VPN.

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -9,6 +9,13 @@ import (
 	"net"
 )
 
+const (
+	// IPv4Family represents the IPv4 IP family.
+	IPv4Family = "ipv4"
+	// IPv6Family represents the IPv6 IP family.
+	IPv6Family = "ipv6"
+)
+
 type CIDR net.IPNet
 
 func (c CIDR) Equal(other CIDR) bool {
@@ -58,4 +65,22 @@ func ParseIPNet(cidr string) (CIDR, error) {
 func ParseIPNetIgnoreError(cidr string) CIDR {
 	parsed, _ := ParseIPNet(cidr)
 	return parsed
+}
+
+// GetByIPFamily returns a list of CIDRs that belong to the given IP family.
+func GetByIPFamily(cidrs []CIDR, ipFamily string) []CIDR {
+	var result []CIDR
+	for _, nw := range cidrs {
+		switch ipFamily {
+		case IPv4Family:
+			if nw.IP.To4() != nil && len(nw.IP) == net.IPv4len {
+				result = append(result, nw)
+			}
+		case IPv6Family:
+			if nw.IP.To16() != nil && len(nw.IP) == net.IPv6len {
+				result = append(result, nw)
+			}
+		}
+	}
+	return result
 }

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	// IPv4Family represents the IPv4 IP family.
-	IPv4Family = "ipv4"
+	IPv4Family = "IPv4"
 	// IPv6Family represents the IPv6 IP family.
-	IPv6Family = "ipv6"
+	IPv6Family = "IPv6"
 )
 
 type CIDR net.IPNet

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	// IPv4Family represents the IPv4 IP family.
+	// IPv4Family represents the IPv4 address family.
 	IPv4Family = "IPv4"
-	// IPv6Family represents the IPv6 IP family.
+	// IPv6Family represents the IPv6 address family.
 	IPv6Family = "IPv6"
 )
 
@@ -73,11 +73,11 @@ func GetByIPFamily(cidrs []CIDR, ipFamily string) []CIDR {
 	for _, nw := range cidrs {
 		switch ipFamily {
 		case IPv4Family:
-			if nw.IP.To4() != nil && len(nw.IP) == net.IPv4len {
+			if nw.IP.To4() != nil {
 				result = append(result, nw)
 			}
 		case IPv6Family:
-			if nw.IP.To16() != nil && len(nw.IP) == net.IPv6len {
+			if nw.IP.To4() == nil {
 				result = append(result, nw)
 			}
 		}

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -11,6 +11,10 @@ import (
 
 type CIDR net.IPNet
 
+func (c CIDR) Equal(other CIDR) bool {
+	return c.IP.Equal(other.IP) && c.Mask.String() == other.Mask.String()
+}
+
 func (c *CIDR) UnmarshalText(text []byte) error {
 	// empty strings are allowed
 	if string(text) == "" {

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -45,10 +45,17 @@ func (c *CIDR) IsIPv4() bool {
 	return c.IP.To4() != nil
 }
 
-func ParseIPNet(cidr string) CIDR {
+// ParseIPNet parses a CIDR string and returns a network.CIDR (for user-provided values)
+func ParseIPNet(cidr string) (CIDR, error) {
 	_, prefix, err := net.ParseCIDR(cidr)
 	if err != nil {
-		panic(err)
+		return CIDR{}, err
 	}
-	return CIDR(*prefix)
+	return CIDR(*prefix), nil
+}
+
+// ParseIPNetIgnoreError parses a CIDR string and ignores any error (for testing and constants)
+func ParseIPNetIgnoreError(cidr string) CIDR {
+	parsed, _ := ParseIPNet(cidr)
+	return parsed
 }

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -36,3 +36,15 @@ func (c CIDR) ToIPNet() *net.IPNet {
 	netw := net.IPNet(c)
 	return &netw
 }
+
+func (c *CIDR) IsIPv4() bool {
+	return c.IP.To4() != nil
+}
+
+func ParseIPNet(cidr string) CIDR {
+	_, prefix, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	return CIDR(*prefix)
+}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -45,5 +45,5 @@ remote {{ .Endpoint }}
 
 {{- if and .IsShootClient (not .IsHA) }}
 script-security 2
-up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetworkMapped }} dev $1' -- "
+up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
 {{- end }}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -45,5 +45,5 @@ remote {{ .Endpoint }}
 
 {{- if and .IsShootClient (not .IsHA) }}
 script-security 2
-up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
+up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetworkV4 }} dev $1' -- "
 {{- end }}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -45,5 +45,5 @@ remote {{ .Endpoint }}
 
 {{- if and .IsShootClient (not .IsHA) }}
 script-security 2
-up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
+up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetworkMapped }} dev $1' -- "
 {{- end }}

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -41,7 +41,7 @@ dev {{ .Device }}
 {{/* Add firewall rules to block all traffic originating from the shoot cluster.
      The scripts are run after the tun device has been created (up) or removed (down). */ -}}
 script-security 2
-up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }}"
+up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }} --seed-network={{ .SeedPodNetwork }}"
 down "/bin/vpn-server firewall --mode down --device {{ .Device }}"
 
 {{ if not (eq .StatusPath "") -}}

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -41,7 +41,7 @@ dev {{ .Device }}
 {{/* Add firewall rules to block all traffic originating from the shoot cluster.
      The scripts are run after the tun device has been created (up) or removed (down). */ -}}
 script-security 2
-up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }} --seed-network={{ .SeedPodNetwork }}"
+up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }} --seed-pod-network-v4={{ .SeedPodNetworkV4 }}"
 down "/bin/vpn-server firewall --mode down --device {{ .Device }}"
 
 {{ if not (eq .StatusPath "") -}}

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -23,7 +23,7 @@ type ClientValues struct {
 	IsShootClient     bool
 	IsHA              bool
 	Device            string
-	SeedPodNetwork    string
+	SeedPodNetworkV4  string
 	IsDualStack       bool
 }
 

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -18,7 +18,7 @@ type ClientValues struct {
 	IPFamily          string
 	ReversedVPNHeader string
 	Endpoint          string
-	OpenVPNPort       int
+	OpenVPNPort       uint
 	VPNClientIndex    int
 	IsShootClient     bool
 	IsHA              bool

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -16,17 +16,16 @@ import (
 var clientTemplate string
 
 type ClientValues struct {
-	IPFamily             string
-	ReversedVPNHeader    string
-	Endpoint             string
-	OpenVPNPort          int
-	VPNClientIndex       int
-	IsShootClient        bool
-	IsHA                 bool
-	Device               string
-	SeedPodNetwork       string
-	SeedPodNetworkMapped string
-	IsDualStack          bool
+	IPFamily          string
+	ReversedVPNHeader string
+	Endpoint          string
+	OpenVPNPort       int
+	VPNClientIndex    int
+	IsShootClient     bool
+	IsHA              bool
+	Device            string
+	SeedPodNetwork    string
+	IsDualStack       bool
 }
 
 func generateClientConfig(cfg ClientValues) (string, error) {

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -5,9 +5,8 @@
 package openvpn
 
 import (
-	_ "embed"
-
 	"bytes"
+	_ "embed"
 	"fmt"
 	"os"
 )

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -16,16 +16,17 @@ import (
 var clientTemplate string
 
 type ClientValues struct {
-	IPFamily          string
-	ReversedVPNHeader string
-	Endpoint          string
-	OpenVPNPort       int
-	VPNClientIndex    int
-	IsShootClient     bool
-	IsHA              bool
-	Device            string
-	SeedPodNetwork    string
-	IsDualStack       bool
+	IPFamily             string
+	ReversedVPNHeader    string
+	Endpoint             string
+	OpenVPNPort          int
+	VPNClientIndex       int
+	IsShootClient        bool
+	IsHA                 bool
+	Device               string
+	SeedPodNetwork       string
+	SeedPodNetworkMapped string
+	IsDualStack          bool
 }
 
 func generateClientConfig(cfg ClientValues) (string, error) {

--- a/pkg/openvpn/config_client_test.go
+++ b/pkg/openvpn/config_client_test.go
@@ -46,7 +46,7 @@ ca /srv/secrets/vpn-client/ca.crt`))
 				OpenVPNPort:       1143,
 				ReversedVPNHeader: "invalid-host",
 				IsShootClient:     true,
-				SeedPodNetwork:    "10.123.0.0/19",
+				SeedPodNetworkV4:  "10.123.0.0/19",
 			}
 
 			content, err := generateClientConfig(cfg)
@@ -88,7 +88,7 @@ up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
 				OpenVPNPort:       1143,
 				ReversedVPNHeader: "invalid-host",
 				IsShootClient:     true,
-				SeedPodNetwork:    "2001:db8:77::/96",
+				SeedPodNetworkV4:  "2001:db8:77::/96",
 			}
 
 			content, err := generateClientConfig(cfg)

--- a/pkg/openvpn/config_client_test.go
+++ b/pkg/openvpn/config_client_test.go
@@ -88,7 +88,7 @@ up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
 				OpenVPNPort:       1143,
 				ReversedVPNHeader: "invalid-host",
 				IsShootClient:     true,
-				SeedPodNetworkV4:  "2001:db8:77::/96",
+				SeedPodNetworkV4:  "10.123.0.0/19",
 			}
 
 			content, err := generateClientConfig(cfg)
@@ -111,7 +111,7 @@ ca /srv/secrets/vpn-client-0/ca.crt
 				It("adds route for seed pod network", func() {
 					Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/sh -c '/sbin/ip route replace 2001:db8:77::/96 dev $1' -- "
+up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
 `))
 				})
 

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -28,6 +28,7 @@ type SeedServerValues struct {
 	ShootNetworks   []network.CIDR
 	ShootNetworksV4 []network.CIDR
 	ShootNetworksV6 []network.CIDR
+	SeedPodNetwork  network.CIDR
 	HAVPNClients    int
 	IsHA            bool
 	VPNIndex        int

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -22,17 +22,17 @@ var (
 )
 
 type SeedServerValues struct {
-	Device          string
-	StatusPath      string
-	OpenVPNNetwork  network.CIDR
-	ShootNetworks   []network.CIDR
-	ShootNetworksV4 []network.CIDR
-	ShootNetworksV6 []network.CIDR
-	SeedPodNetwork  network.CIDR
-	HAVPNClients    int
-	IsHA            bool
-	VPNIndex        int
-	LocalNodeIP     string
+	Device           string
+	StatusPath       string
+	OpenVPNNetwork   network.CIDR
+	ShootNetworks    []network.CIDR
+	ShootNetworksV4  []network.CIDR
+	ShootNetworksV6  []network.CIDR
+	SeedPodNetworkV4 network.CIDR
+	HAVPNClients     int
+	IsHA             bool
+	VPNIndex         int
+	LocalNodeIP      string
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -5,8 +5,6 @@
 package openvpn
 
 import (
-	"net"
-
 	"github.com/gardener/vpn2/pkg/network"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,7 +19,7 @@ var _ = Describe("#SeedServerConfig", func() {
 		prepareIPv4HA = func() {
 			cfgIPv4.IsHA = true
 			cfgIPv4.Device = "tap0"
-			cfgIPv4.OpenVPNNetwork = parseIPNet("fd8f:6d53:b97a:7777::/96")
+			cfgIPv4.OpenVPNNetwork = network.ParseIPNet("fd8f:6d53:b97a:7777::/96")
 			cfgIPv4.StatusPath = "/srv/status/openvpn.status"
 		}
 	)
@@ -29,55 +27,55 @@ var _ = Describe("#SeedServerConfig", func() {
 	BeforeEach(func() {
 		cfgIPv4 = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				parseIPNet("100.64.0.0/13"),
-				parseIPNet("100.96.0.0/11"),
-				parseIPNet("10.0.1.0/24"),
+				network.ParseIPNet("100.64.0.0/13"),
+				network.ParseIPNet("100.96.0.0/11"),
+				network.ParseIPNet("10.0.1.0/24"),
 			},
 			ShootNetworksV4: []network.CIDR{
-				parseIPNet("100.64.0.0/13"),
-				parseIPNet("100.96.0.0/11"),
-				parseIPNet("10.0.1.0/24"),
+				network.ParseIPNet("100.64.0.0/13"),
+				network.ParseIPNet("100.96.0.0/11"),
+				network.ParseIPNet("10.0.1.0/24"),
 			},
 		}
 		cfgIPv6 = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				parseIPNet("2001:db8:1::/48"),
-				parseIPNet("2001:db8:2::/48"),
-				parseIPNet("2001:db8:3::/48"),
+				network.ParseIPNet("2001:db8:1::/48"),
+				network.ParseIPNet("2001:db8:2::/48"),
+				network.ParseIPNet("2001:db8:3::/48"),
 			},
 			ShootNetworksV6: []network.CIDR{
-				parseIPNet("2001:db8:1::/48"),
-				parseIPNet("2001:db8:2::/48"),
-				parseIPNet("2001:db8:3::/48"),
+				network.ParseIPNet("2001:db8:1::/48"),
+				network.ParseIPNet("2001:db8:2::/48"),
+				network.ParseIPNet("2001:db8:3::/48"),
 			},
 		}
 		cfgDualStack = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: parseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				parseIPNet("100.64.0.0/13"),
-				parseIPNet("100.96.0.0/11"),
-				parseIPNet("10.0.1.0/24"),
-				parseIPNet("2001:db8:1::/48"),
-				parseIPNet("2001:db8:2::/48"),
-				parseIPNet("2001:db8:3::/48"),
+				network.ParseIPNet("100.64.0.0/13"),
+				network.ParseIPNet("100.96.0.0/11"),
+				network.ParseIPNet("10.0.1.0/24"),
+				network.ParseIPNet("2001:db8:1::/48"),
+				network.ParseIPNet("2001:db8:2::/48"),
+				network.ParseIPNet("2001:db8:3::/48"),
 			},
 			ShootNetworksV4: []network.CIDR{
-				parseIPNet("100.64.0.0/13"),
-				parseIPNet("100.96.0.0/11"),
-				parseIPNet("10.0.1.0/24"),
+				network.ParseIPNet("100.64.0.0/13"),
+				network.ParseIPNet("100.96.0.0/11"),
+				network.ParseIPNet("10.0.1.0/24"),
 			},
 			ShootNetworksV6: []network.CIDR{
-				parseIPNet("2001:db8:1::/48"),
-				parseIPNet("2001:db8:2::/48"),
-				parseIPNet("2001:db8:3::/48"),
+				network.ParseIPNet("2001:db8:1::/48"),
+				network.ParseIPNet("2001:db8:2::/48"),
+				network.ParseIPNet("2001:db8:3::/48"),
 			},
 		}
 	})
@@ -223,11 +221,3 @@ iroute-ipv6 2001:db8:3::/48
 		})
 	})
 })
-
-func parseIPNet(cidr string) network.CIDR {
-	_, prefix, err := net.ParseCIDR(cidr)
-	if err != nil {
-		panic(err)
-	}
-	return network.CIDR(*prefix)
-}

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -20,7 +20,7 @@ var _ = Describe("#SeedServerConfig", func() {
 		prepareIPv4HA = func() {
 			cfgIPv4.IsHA = true
 			cfgIPv4.Device = "tap0"
-			cfgIPv4.OpenVPNNetwork = network.ParseIPNet("fd8f:6d53:b97a:7777::/96")
+			cfgIPv4.OpenVPNNetwork = network.ParseIPNetIgnoreError("fd8f:6d53:b97a:7777::/96")
 			cfgIPv4.StatusPath = "/srv/status/openvpn.status"
 		}
 	)
@@ -28,59 +28,59 @@ var _ = Describe("#SeedServerConfig", func() {
 	BeforeEach(func() {
 		cfgIPv4 = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNetIgnoreError("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				network.ParseIPNet("100.64.0.0/13"),
-				network.ParseIPNet("100.96.0.0/11"),
-				network.ParseIPNet("10.0.1.0/24"),
+				network.ParseIPNetIgnoreError("100.64.0.0/13"),
+				network.ParseIPNetIgnoreError("100.96.0.0/11"),
+				network.ParseIPNetIgnoreError("10.0.1.0/24"),
 			},
 			ShootNetworksV4: []network.CIDR{
-				network.ParseIPNet("100.64.0.0/13"),
-				network.ParseIPNet("100.96.0.0/11"),
-				network.ParseIPNet("10.0.1.0/24"),
+				network.ParseIPNetIgnoreError("100.64.0.0/13"),
+				network.ParseIPNetIgnoreError("100.96.0.0/11"),
+				network.ParseIPNetIgnoreError("10.0.1.0/24"),
 			},
-			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 		cfgIPv6 = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNetIgnoreError("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				network.ParseIPNet("2001:db8:1::/48"),
-				network.ParseIPNet("2001:db8:2::/48"),
-				network.ParseIPNet("2001:db8:3::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:1::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
 			ShootNetworksV6: []network.CIDR{
-				network.ParseIPNet("2001:db8:1::/48"),
-				network.ParseIPNet("2001:db8:2::/48"),
-				network.ParseIPNet("2001:db8:3::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:1::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
-			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 		cfgDualStack = SeedServerValues{
 			Device:         "tun0",
-			OpenVPNNetwork: network.ParseIPNet("fd8f:6d53:b97a:7777::/96"),
+			OpenVPNNetwork: network.ParseIPNetIgnoreError("fd8f:6d53:b97a:7777::/96"),
 			IsHA:           false,
 			ShootNetworks: []network.CIDR{
-				network.ParseIPNet("100.64.0.0/13"),
-				network.ParseIPNet("100.96.0.0/11"),
-				network.ParseIPNet("10.0.1.0/24"),
-				network.ParseIPNet("2001:db8:1::/48"),
-				network.ParseIPNet("2001:db8:2::/48"),
-				network.ParseIPNet("2001:db8:3::/48"),
+				network.ParseIPNetIgnoreError("100.64.0.0/13"),
+				network.ParseIPNetIgnoreError("100.96.0.0/11"),
+				network.ParseIPNetIgnoreError("10.0.1.0/24"),
+				network.ParseIPNetIgnoreError("2001:db8:1::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
 			ShootNetworksV4: []network.CIDR{
-				network.ParseIPNet("100.64.0.0/13"),
-				network.ParseIPNet("100.96.0.0/11"),
-				network.ParseIPNet("10.0.1.0/24"),
+				network.ParseIPNetIgnoreError("100.64.0.0/13"),
+				network.ParseIPNetIgnoreError("100.96.0.0/11"),
+				network.ParseIPNetIgnoreError("10.0.1.0/24"),
 			},
 			ShootNetworksV6: []network.CIDR{
-				network.ParseIPNet("2001:db8:1::/48"),
-				network.ParseIPNet("2001:db8:2::/48"),
-				network.ParseIPNet("2001:db8:3::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:1::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
+				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
-			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 	})
 

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -5,9 +5,10 @@
 package openvpn
 
 import (
-	"github.com/gardener/vpn2/pkg/network"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/vpn2/pkg/network"
 )
 
 var _ = Describe("#SeedServerConfig", func() {

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -40,7 +40,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("100.96.0.0/11"),
 				network.ParseIPNet("10.0.1.0/24"),
 			},
-			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
 		}
 		cfgIPv6 = SeedServerValues{
 			Device:         "tun0",
@@ -56,7 +56,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("2001:db8:2::/48"),
 				network.ParseIPNet("2001:db8:3::/48"),
 			},
-			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
 		}
 		cfgDualStack = SeedServerValues{
 			Device:         "tun0",
@@ -80,7 +80,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("2001:db8:2::/48"),
 				network.ParseIPNet("2001:db8:3::/48"),
 			},
-			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
+			SeedPodNetworkV4: network.ParseIPNet("100.64.0.0/12"),
 		}
 	})
 
@@ -101,8 +101,9 @@ server-ipv6 fd8f:6d53:b97a:7777::/96
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-network=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network-v4=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
+			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
 
 		It("should generate correct openvpn.config for IPv4 default values with HA", func() {
@@ -128,12 +129,13 @@ dev tap0
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-network=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network-v4=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tap0"`))
 
 			Expect(content).To(ContainSubstring(`
 status /srv/status/openvpn.status 15
 status-version 2`))
+			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
 
 		It("should generate correct openvpn.config for IPv6 default values", func() {
@@ -151,8 +153,9 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-network=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network-v4=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
+			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
 
 		It("should generate correct openvpn.config for dual stack values", func() {
@@ -170,8 +173,9 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-network=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network-v4=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
+			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
 	})
 

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -39,6 +39,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("100.96.0.0/11"),
 				network.ParseIPNet("10.0.1.0/24"),
 			},
+			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
 		}
 		cfgIPv6 = SeedServerValues{
 			Device:         "tun0",
@@ -54,6 +55,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("2001:db8:2::/48"),
 				network.ParseIPNet("2001:db8:3::/48"),
 			},
+			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
 		}
 		cfgDualStack = SeedServerValues{
 			Device:         "tun0",
@@ -77,6 +79,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNet("2001:db8:2::/48"),
 				network.ParseIPNet("2001:db8:3::/48"),
 			},
+			SeedPodNetwork: network.ParseIPNet("100.64.0.0/12"),
 		}
 	})
 
@@ -97,7 +100,7 @@ server-ipv6 fd8f:6d53:b97a:7777::/96
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 		})
 
@@ -124,7 +127,7 @@ dev tap0
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24"
+up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tap0"`))
 
 			Expect(content).To(ContainSubstring(`
@@ -147,7 +150,7 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 		})
 
@@ -166,7 +169,7 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 		})
 	})

--- a/pkg/openvpn/openvpn_test.go
+++ b/pkg/openvpn/openvpn_test.go
@@ -5,13 +5,52 @@
 package openvpn
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 func TestOpenVPN(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "OpenVPN Suite")
+}
+
+// OpenVPNConfigMaxLineLength is the maximum length of a line in an OpenVPN configuration file.
+// see https://github.com/OpenVPN/openvpn/blob/master/src/openvpn/options.h#L58
+// With dual-stack shoots plus the seed pod network, the configuration can get quite long so we have to check for this.
+const OpenVPNConfigMaxLineLength = 256
+
+func HaveNoLineLongerThan(maxLength int) types.GomegaMatcher {
+	return &noLineLongerThanMatcher{maxLength: maxLength}
+}
+
+type noLineLongerThanMatcher struct {
+	maxLength int
+}
+
+func (matcher *noLineLongerThanMatcher) Match(actual interface{}) (success bool, err error) {
+	content, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("HaveNoLineLongerThan matcher expects a string")
+	}
+
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		if len(line) > matcher.maxLength {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (matcher *noLineLongerThanMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%s\nto have no line longer than %d characters", actual, matcher.maxLength)
+}
+
+func (matcher *noLineLongerThanMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%s\nto have at least one line longer than %d characters", actual, matcher.maxLength)
 }

--- a/pkg/shoot_client/tunnel/tunnel.go
+++ b/pkg/shoot_client/tunnel/tunnel.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/vpn2/pkg/constants"
-	"github.com/gardener/vpn2/pkg/network"
 	"github.com/go-logr/logr"
 	"github.com/vishvananda/netlink"
 	"k8s.io/utils/ptr"
+
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
 )
 
 const (

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -116,6 +116,7 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 
 	if !cfg.IsShootClient {
 		for i := range cfg.HAVPNClients {
+			// #nosec: G115 -- overflow unlikely (max value at least 2147483647 before overflow)
 			if err := network.CreateTunnel(network.BondIP6TunnelLinkName(int(i)), addr.IP, network.BondingShootClientIP(cfg.VPNNetwork.ToIPNet(), int(i))); err != nil {
 				return fmt.Errorf("failed to create tunnel ip6-net link: %w", err)
 			}

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -116,7 +116,7 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 
 	if !cfg.IsShootClient {
 		for i := range cfg.HAVPNClients {
-			if err := network.CreateTunnel(network.BondIP6TunnelLinkName(i), addr.IP, network.BondingShootClientIP(cfg.VPNNetwork.ToIPNet(), i)); err != nil {
+			if err := network.CreateTunnel(network.BondIP6TunnelLinkName(int(i)), addr.IP, network.BondingShootClientIP(cfg.VPNNetwork.ToIPNet(), int(i))); err != nil {
 				return fmt.Errorf("failed to create tunnel ip6-net link: %w", err)
 			}
 		}

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -10,12 +10,13 @@ import (
 	"net"
 	"os/exec"
 
+	"github.com/go-logr/logr"
+	"github.com/vishvananda/netlink"
+
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
 	"github.com/gardener/vpn2/pkg/ippool"
 	"github.com/gardener/vpn2/pkg/network"
-	"github.com/go-logr/logr"
-	"github.com/vishvananda/netlink"
 )
 
 func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClient) error {

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -41,15 +41,15 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 					log.Info("setting up double NAT IPv4 iptables rules")
 					ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
 					if len(ipv4PodNetworks) > 1 {
-						return fmt.Errorf("exactly one v4 pod network is supported. v4 pod networks: %s", ipv4PodNetworks)
+						return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
 					}
 					ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
 					if len(ipv4ServiceNetworks) > 1 {
-						return fmt.Errorf("exactly one v4 service network is supported. v4 service networks: %s", ipv4ServiceNetworks)
+						return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
 					}
 					ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
 					if len(ipv4NodeNetworks) > 1 {
-						return fmt.Errorf("exactly one v4 node network is supported. v4 node networks: %s", ipv4NodeNetworks)
+						return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
 					}
 
 					for _, nw := range ipv4PodNetworks {

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -5,12 +5,14 @@
 package vpn_client
 
 import (
+	"strings"
+
 	"github.com/coreos/go-iptables/iptables"
+	"github.com/go-logr/logr"
+
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
 	"github.com/gardener/vpn2/pkg/network"
-	"github.com/go-logr/logr"
-	"strings"
 )
 
 func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -35,6 +35,30 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				if err != nil {
 					return err
 				}
+				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootPodNetwork.String())
+				if err != nil {
+					return err
+				}
+				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootPodNetwork.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+				if err != nil {
+					return err
+				}
+				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootSvcNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootServiceNetwork.String())
+				if err != nil {
+					return err
+				}
+				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootServiceNetwork.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
+				if err != nil {
+					return err
+				}
+				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootNodeNetwork.String())
+				if err != nil {
+					return err
+				}
+				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootNodeNetwork.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+				if err != nil {
+					return err
+				}
 			}
 
 			err = ipTable.Append("filter", "FORWARD", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--clamp-mss-to-pmtu")

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -5,8 +5,6 @@
 package vpn_client
 
 import (
-	"strings"
-
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/go-logr/logr"
 
@@ -21,7 +19,7 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 		forwardDevice = constants.BondDevice
 	}
 
-	for _, family := range strings.Split(cfg.IPFamilies, ",") {
+	for _, family := range cfg.IPFamilies {
 		protocol := iptables.ProtocolIPv4
 		if family == constants.IPv6Family {
 			protocol = iptables.ProtocolIPv6

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -38,27 +38,27 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 					return err
 				}
 				if !cfg.IsHA {
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootPodNetwork.String())
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootPodNetworkV4.String())
 					if err != nil {
 						return err
 					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootPodNetwork.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootPodNetworkV4.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
 					if err != nil {
 						return err
 					}
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootSvcNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootServiceNetwork.String())
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootServiceNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootServiceNetworkV4.String())
 					if err != nil {
 						return err
 					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootServiceNetwork.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootServiceNetworkV4.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
 					if err != nil {
 						return err
 					}
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootNodeNetwork.String())
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootNodeNetworkV4.String())
 					if err != nil {
 						return err
 					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootNodeNetwork.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootNodeNetworkV4.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
 					if err != nil {
 						return err
 					}

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -14,7 +14,7 @@ import (
 )
 
 func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
-	forwardDevice := "tun0"
+	forwardDevice := constants.TunnelDevice
 	if cfg.VPNServerIndex != "" {
 		forwardDevice = constants.BondDevice
 	}
@@ -35,29 +35,31 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				if err != nil {
 					return err
 				}
-				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootPodNetwork.String())
-				if err != nil {
-					return err
-				}
-				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootPodNetwork.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
-				if err != nil {
-					return err
-				}
-				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootSvcNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootServiceNetwork.String())
-				if err != nil {
-					return err
-				}
-				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootServiceNetwork.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
-				if err != nil {
-					return err
-				}
-				err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootNodeNetwork.String())
-				if err != nil {
-					return err
-				}
-				err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootNodeNetwork.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
-				if err != nil {
-					return err
+				if !cfg.IsHA {
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootPodNetwork.String())
+					if err != nil {
+						return err
+					}
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootPodNetwork.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+					if err != nil {
+						return err
+					}
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootSvcNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootServiceNetwork.String())
+					if err != nil {
+						return err
+					}
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootServiceNetwork.String(), "-j", "NETMAP", "--to", constants.ShootSvcNetworkMapped)
+					if err != nil {
+						return err
+					}
+					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", cfg.ShootNodeNetwork.String())
+					if err != nil {
+						return err
+					}
+					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.ShootNodeNetwork.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+					if err != nil {
+						return err
+					}
 				}
 			}
 

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/sysctl"
-	"github.com/gardener/vpn2/pkg/config"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/vpn2/pkg/config"
 )
 
 // EnableIPv6Networking enables IPv6 networking on the system.

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -45,15 +45,18 @@ func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 		return err
 	}
 	// Set the keepalive time for TCP connections.
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_time", cfg.TCP.KeepAliveTime); err != nil {
+	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
+	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_time", int64(cfg.TCP.KeepAliveTime)); err != nil {
 		return err
 	}
 	// Set the keepalive interval for TCP connections.
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_intvl", cfg.TCP.KeepAliveInterval); err != nil {
+	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
+	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_intvl", int64(cfg.TCP.KeepAliveInterval)); err != nil {
 		return err
 	}
 	// Set the number of keepalive probes for TCP connections.
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_probes", cfg.TCP.KeepAliveProbes); err != nil {
+	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
+	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_probes", int64(cfg.TCP.KeepAliveProbes)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/vpn_server/iptables.go
+++ b/pkg/vpn_server/iptables.go
@@ -21,15 +21,15 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNServer) error {
 
 		ipv4PodNetworks := network.GetByIPFamily(cfg.PodNetworks, network.IPv4Family)
 		if len(ipv4PodNetworks) > 1 {
-			return fmt.Errorf("exactly one v4 pod network is supported. v4 pod networks: %s", ipv4PodNetworks)
+			return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
 		}
 		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ServiceNetworks, network.IPv4Family)
 		if len(ipv4ServiceNetworks) > 1 {
-			return fmt.Errorf("exactly one v4 service network is supported. v4 service networks: %s", ipv4ServiceNetworks)
+			return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
 		}
 		ipv4NodeNetworks := network.GetByIPFamily(cfg.NodeNetworks, network.IPv4Family)
 		if len(ipv4NodeNetworks) > 1 {
-			return fmt.Errorf("exactly one v4 node network is supported. v4 node networks: %s", ipv4NodeNetworks)
+			return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
 		}
 
 		for _, nw := range ipv4PodNetworks {

--- a/pkg/vpn_server/iptables.go
+++ b/pkg/vpn_server/iptables.go
@@ -1,0 +1,55 @@
+package vpn_server
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/go-logr/logr"
+
+	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
+)
+
+func SetIPTableRules(log logr.Logger, cfg config.VPNServer) error {
+	if !cfg.IsHA {
+		log.Info("setting up double NAT IPv4 iptables rules")
+		ipTable, err := network.NewIPTables(log, iptables.ProtocolIPv4)
+		if err != nil {
+			return err
+		}
+
+		ipv4PodNetworks := network.GetByIPFamily(cfg.PodNetworks, network.IPv4Family)
+		if len(ipv4PodNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 pod network is supported. v4 pod networks: %s", ipv4PodNetworks)
+		}
+		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ServiceNetworks, network.IPv4Family)
+		if len(ipv4ServiceNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 service network is supported. v4 service networks: %s", ipv4ServiceNetworks)
+		}
+		ipv4NodeNetworks := network.GetByIPFamily(cfg.NodeNetworks, network.IPv4Family)
+		if len(ipv4NodeNetworks) > 1 {
+			return fmt.Errorf("exactly one v4 node network is supported. v4 node networks: %s", ipv4NodeNetworks)
+		}
+
+		for _, nw := range ipv4PodNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+			if err != nil {
+				return err
+			}
+		}
+		for _, nw := range ipv4ServiceNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
+			if err != nil {
+				return err
+			}
+		}
+		for _, nw := range ipv4NodeNetworks {
+			err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--uid-owner", constants.EnvoyNonRootUserId, "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -55,21 +55,21 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		// v4 networks are mapped to 240/4, v6 networks are kept as is
 		for _, serviceNetwork := range cfg.ServiceNetworks {
 			if serviceNetwork.IP.To4() != nil {
-				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootServiceNetworkMapped))
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootServiceNetworkMapped))
 			} else {
 				v.ShootNetworks = append(v.ShootNetworks, serviceNetwork)
 			}
 		}
 		for _, podNetwork := range cfg.PodNetworks {
 			if podNetwork.IP.To4() != nil {
-				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootPodNetworkMapped))
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootPodNetworkMapped))
 			} else {
 				v.ShootNetworks = append(v.ShootNetworks, podNetwork)
 			}
 		}
 		for _, nodeNetwork := range cfg.NodeNetworks {
 			if nodeNetwork.IP.To4() != nil {
-				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootNodeNetworkMapped))
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootNodeNetworkMapped))
 			} else {
 				v.ShootNetworks = append(v.ShootNetworks, nodeNetwork)
 			}

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -46,7 +46,6 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		if len(cfg.NodeNetworks) != 0 && cfg.NodeNetworks[0].String() != "" {
 			v.ShootNetworks = append(v.ShootNetworks, cfg.NodeNetworks...)
 		}
-
 	case false:
 		v.Device = constants.TunnelDevice
 		v.HAVPNClients = -1

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -51,11 +51,11 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		v.HAVPNClients = -1
 		v.OpenVPNNetwork = cfg.VPNNetwork
 
-		v.SeedPodNetwork = cfg.SeedPodNetwork
+		v.SeedPodNetworkV4 = cfg.SeedPodNetworkV4
 		// v4 networks are mapped to 240/4, v6 networks are kept as is
 		for _, serviceNetwork := range cfg.ServiceNetworks {
 			if serviceNetwork.IP.To4() != nil {
-				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootSvcNetworkMapped))
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootServiceNetworkMapped))
 			} else {
 				v.ShootNetworks = append(v.ShootNetworks, serviceNetwork)
 			}

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -22,7 +22,10 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		StatusPath: cfg.StatusPath,
 	}
 
-	if len(cfg.VPNNetwork.IP) != 16 {
+	if cfg.VPNNetwork.IP == nil {
+		return v, fmt.Errorf("VPN_NETWORK must be set")
+	}
+	if cfg.VPNNetwork.IsIPv4() {
 		return v, fmt.Errorf("VPN_NETWORK must be a IPv6 CIDR: %s", cfg.VPNNetwork)
 	}
 	if ones, _ := cfg.VPNNetwork.Mask.Size(); ones != constants.VPNNetworkMask {

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -32,7 +32,7 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 
 	switch v.IsHA {
 	case true:
-		v.Device = "tap0"
+		v.Device = constants.TapDevice
 		v.HAVPNClients = cfg.HAVPNClients
 		v.OpenVPNNetwork = network.HAVPNTunnelNetwork(cfg.VPNNetwork.IP, v.VPNIndex)
 
@@ -43,7 +43,7 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		}
 
 	case false:
-		v.Device = "tun0"
+		v.Device = constants.TunnelDevice
 		v.HAVPNClients = -1
 		v.OpenVPNNetwork = cfg.VPNNetwork
 

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -52,7 +52,7 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		v.OpenVPNNetwork = cfg.VPNNetwork
 
 		v.SeedPodNetworkV4 = cfg.SeedPodNetworkV4
-		// v4 networks are mapped to 240/4, v6 networks are kept as is
+		// IPv4 networks are mapped to 240/4, IPv6 networks are kept as is
 		for _, serviceNetwork := range cfg.ServiceNetworks {
 			if serviceNetwork.IP.To4() != nil {
 				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootServiceNetworkMapped))

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -48,9 +48,28 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		v.OpenVPNNetwork = cfg.VPNNetwork
 
 		v.SeedPodNetwork = cfg.SeedPodNetwork
-		v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootNodeNetworkMapped))
-		v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootSvcNetworkMapped))
-		v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootPodNetworkMapped))
+		// v4 networks are mapped to 240/4, v6 networks are kept as is
+		for _, serviceNetwork := range cfg.ServiceNetworks {
+			if serviceNetwork.IP.To4() != nil {
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootSvcNetworkMapped))
+			} else {
+				v.ShootNetworks = append(v.ShootNetworks, serviceNetwork)
+			}
+		}
+		for _, podNetwork := range cfg.PodNetworks {
+			if podNetwork.IP.To4() != nil {
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootPodNetworkMapped))
+			} else {
+				v.ShootNetworks = append(v.ShootNetworks, podNetwork)
+			}
+		}
+		for _, nodeNetwork := range cfg.NodeNetworks {
+			if nodeNetwork.IP.To4() != nil {
+				v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNet(constants.ShootNodeNetworkMapped))
+			} else {
+				v.ShootNetworks = append(v.ShootNetworks, nodeNetwork)
+			}
+		}
 	}
 
 	for _, shootNetwork := range v.ShootNetworks {

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -42,7 +42,7 @@ var _ = Describe("BuildValues", func() {
 		})
 		Context("when VPN_NETWORK is not a IPv6 CIDR", func() {
 			BeforeEach(func() {
-				cfg.VPNNetwork = network.ParseIPNet("192.168.0.0/24")
+				cfg.VPNNetwork = network.ParseIPNetIgnoreError("192.168.0.0/24")
 			})
 
 			It("should return an error", func() {
@@ -53,7 +53,7 @@ var _ = Describe("BuildValues", func() {
 		})
 		Context("when VPN_NETWORK is not a /96 IPv6 CIDR", func() {
 			BeforeEach(func() {
-				cfg.VPNNetwork = network.ParseIPNet("2001:db8::/64")
+				cfg.VPNNetwork = network.ParseIPNetIgnoreError("2001:db8::/64")
 			})
 
 			It("should return an error", func() {
@@ -64,7 +64,7 @@ var _ = Describe("BuildValues", func() {
 		})
 		Context("when VPN_NETWORK is a /96 IPv6 CIDR", func() {
 			BeforeEach(func() {
-				cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+				cfg.VPNNetwork = network.ParseIPNetIgnoreError("2001:db8::/96")
 			})
 
 			It("should pass", func() {
@@ -76,7 +76,7 @@ var _ = Describe("BuildValues", func() {
 
 	Describe("HA", func() {
 		BeforeEach(func() {
-			cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+			cfg.VPNNetwork = network.ParseIPNetIgnoreError("2001:db8::/96")
 		})
 		Context("when IS_HA is set", func() {
 			BeforeEach(func() {
@@ -107,9 +107,9 @@ var _ = Describe("BuildValues", func() {
 				Context("when networks are set (v4)", func() {
 					var v4Networks []network.CIDR
 					BeforeEach(func() {
-						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("100.80.0.0/16")}
-						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("100.81.0.0/16")}
-						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("100.82.0.0/16")}
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.80.0.0/16")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.81.0.0/16")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.82.0.0/16")}
 						v4Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
 					})
 					It("should configure HA VPN correctly (v4)", func() {
@@ -135,9 +135,9 @@ var _ = Describe("BuildValues", func() {
 					Context("when networks are set (v4 + v6)", func() {
 						var v6Networks []network.CIDR
 						BeforeEach(func() {
-							v6Services := network.ParseIPNet("2001:db8:1::/64")
-							v6Pods := network.ParseIPNet("2001:db8:2::/64")
-							v6Nodes := network.ParseIPNet("2001:db8:3::/64")
+							v6Services := network.ParseIPNetIgnoreError("2001:db8:1::/64")
+							v6Pods := network.ParseIPNetIgnoreError("2001:db8:2::/64")
+							v6Nodes := network.ParseIPNetIgnoreError("2001:db8:3::/64")
 							cfg.ServiceNetworks = append(cfg.ServiceNetworks, v6Services)
 							cfg.PodNetworks = append(cfg.PodNetworks, v6Pods)
 							cfg.NodeNetworks = append(cfg.NodeNetworks, v6Nodes)
@@ -168,9 +168,9 @@ var _ = Describe("BuildValues", func() {
 				Context("when networks are set (v6)", func() {
 					var v6Networks []network.CIDR
 					BeforeEach(func() {
-						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("2001:db8:1::/64")}
-						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("2001:db8:2::/64")}
-						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("2001:db8:3::/64")}
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/64")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/64")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/64")}
 						v6Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
 					})
 					It("should configure HA VPN correctly (v6)", func() {
@@ -200,7 +200,7 @@ var _ = Describe("BuildValues", func() {
 
 	Describe("non-HA", func() {
 		BeforeEach(func() {
-			cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+			cfg.VPNNetwork = network.ParseIPNetIgnoreError("2001:db8::/96")
 		})
 		Context("when IS_HA is not set", func() {
 			It("should be false", func() {
@@ -238,13 +238,13 @@ var _ = Describe("BuildValues", func() {
 				Context("when networks are set (v4)", func() {
 					var v4NetworksMapped []network.CIDR
 					BeforeEach(func() {
-						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("100.80.0.0/16")}
-						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("100.81.0.0/16")}
-						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("100.82.0.0/16")}
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.80.0.0/16")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.81.0.0/16")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("100.82.0.0/16")}
 						v4NetworksMapped = []network.CIDR{
-							network.ParseIPNet(constants.ShootNodeNetworkMapped),
-							network.ParseIPNet(constants.ShootServiceNetworkMapped),
-							network.ParseIPNet(constants.ShootPodNetworkMapped),
+							network.ParseIPNetIgnoreError(constants.ShootNodeNetworkMapped),
+							network.ParseIPNetIgnoreError(constants.ShootServiceNetworkMapped),
+							network.ParseIPNetIgnoreError(constants.ShootPodNetworkMapped),
 						}
 					})
 					It("should configure HA VPN correctly (v4)", func() {
@@ -270,9 +270,9 @@ var _ = Describe("BuildValues", func() {
 					Context("when networks are set (v4 + v6)", func() {
 						var v6Networks []network.CIDR
 						BeforeEach(func() {
-							v6Services := network.ParseIPNet("2001:db8:1::/64")
-							v6Pods := network.ParseIPNet("2001:db8:2::/64")
-							v6Nodes := network.ParseIPNet("2001:db8:3::/64")
+							v6Services := network.ParseIPNetIgnoreError("2001:db8:1::/64")
+							v6Pods := network.ParseIPNetIgnoreError("2001:db8:2::/64")
+							v6Nodes := network.ParseIPNetIgnoreError("2001:db8:3::/64")
 							cfg.ServiceNetworks = append(cfg.ServiceNetworks, v6Services)
 							cfg.PodNetworks = append(cfg.PodNetworks, v6Pods)
 							cfg.NodeNetworks = append(cfg.NodeNetworks, v6Nodes)
@@ -303,9 +303,9 @@ var _ = Describe("BuildValues", func() {
 				Context("when networks are set (v6)", func() {
 					var v6Networks []network.CIDR
 					BeforeEach(func() {
-						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("2001:db8:1::/64")}
-						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("2001:db8:2::/64")}
-						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("2001:db8:3::/64")}
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/64")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/64")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/64")}
 						v6Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
 					})
 					It("should configure HA VPN correctly (v6)", func() {

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -37,7 +37,7 @@ var _ = Describe("BuildValues", func() {
 			It("should return an error", func() {
 				_, err := vpn_server.BuildValues(cfg)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("VPN_NETWORK must be a IPv6 CIDR: " + cfg.VPNNetwork.String()))
+				Expect(err).To(MatchError("VPN_NETWORK must be set"))
 			})
 		})
 		Context("when VPN_NETWORK is not a IPv6 CIDR", func() {

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -27,7 +27,7 @@ var _ = Describe("BuildValues", func() {
 
 	BeforeEach(func() {
 		cfg = config.VPNServer{
-			StatusPath:  "/status",
+			StatusPath:  "/srv/status/openvpn.status",
 			LocalNodeIP: "10.10.10.10",
 		}
 	})
@@ -243,7 +243,7 @@ var _ = Describe("BuildValues", func() {
 						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("100.82.0.0/16")}
 						v4NetworksMapped = []network.CIDR{
 							network.ParseIPNet(constants.ShootNodeNetworkMapped),
-							network.ParseIPNet(constants.ShootSvcNetworkMapped),
+							network.ParseIPNet(constants.ShootServiceNetworkMapped),
 							network.ParseIPNet(constants.ShootPodNetworkMapped),
 						}
 					})

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vpn_server_test
+
+import (
+	"slices"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
+	"github.com/gardener/vpn2/pkg/vpn_server"
+)
+
+func TestVPNServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VPNServer Suite")
+}
+
+var _ = Describe("BuildValues", func() {
+	var cfg config.VPNServer
+
+	BeforeEach(func() {
+		cfg = config.VPNServer{
+			StatusPath:  "/status",
+			LocalNodeIP: "10.10.10.10",
+		}
+	})
+
+	Describe("VPN_NETWORK", func() {
+		Context("when VPN_NETWORK is not set", func() {
+			It("should return an error", func() {
+				_, err := vpn_server.BuildValues(cfg)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("VPN_NETWORK must be a IPv6 CIDR: " + cfg.VPNNetwork.String()))
+			})
+		})
+		Context("when VPN_NETWORK is not a IPv6 CIDR", func() {
+			BeforeEach(func() {
+				cfg.VPNNetwork = network.ParseIPNet("192.168.0.0/24")
+			})
+
+			It("should return an error", func() {
+				_, err := vpn_server.BuildValues(cfg)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("VPN_NETWORK must be a IPv6 CIDR: " + cfg.VPNNetwork.String()))
+			})
+		})
+		Context("when VPN_NETWORK is not a /96 IPv6 CIDR", func() {
+			BeforeEach(func() {
+				cfg.VPNNetwork = network.ParseIPNet("2001:db8::/64")
+			})
+
+			It("should return an error", func() {
+				_, err := vpn_server.BuildValues(cfg)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("invalid prefix length for VPN_NETWORK, must be /96, vpn network: " + cfg.VPNNetwork.String()))
+			})
+		})
+		Context("when VPN_NETWORK is a /96 IPv6 CIDR", func() {
+			BeforeEach(func() {
+				cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+			})
+
+			It("should pass", func() {
+				_, err := vpn_server.BuildValues(cfg)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("HA", func() {
+		BeforeEach(func() {
+			cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+		})
+		Context("when IS_HA is set", func() {
+			BeforeEach(func() {
+				cfg.IsHA = true
+				cfg.HAVPNClients = 3
+			})
+			It("should fail due to missing pod name", func() {
+				_, err := vpn_server.BuildValues(cfg)
+				Expect(err).To(MatchError("IS_HA flag in config does not match HA info from pod name: IS_HA = true, POD_NAME = "))
+			})
+			Context("when pod name is set non-stateful", func() {
+				BeforeEach(func() {
+					cfg.PodName = "vpn-seed-server-5d99b56fcb-2h58x"
+				})
+				It("should fail", func() {
+					_, err := vpn_server.BuildValues(cfg)
+					Expect(err).To(MatchError("IS_HA flag in config does not match HA info from pod name: IS_HA = true, POD_NAME = vpn-seed-server-5d99b56fcb-2h58x"))
+				})
+			})
+			Context("when pod name is set", func() {
+				BeforeEach(func() {
+					cfg.PodName = "vpn-seed-server-1"
+				})
+				It("should pass", func() {
+					_, err := vpn_server.BuildValues(cfg)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				Context("when networks are set (v4)", func() {
+					var v4Networks []network.CIDR
+					BeforeEach(func() {
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("100.80.0.0/16")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("100.81.0.0/16")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("100.82.0.0/16")}
+						v4Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
+					})
+					It("should configure HA VPN correctly (v4)", func() {
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.IsHA).To(BeTrue())
+						Expect(v.VPNIndex).To(Equal(1))
+						Expect(v.Device).To(Equal(constants.TapDevice))
+						Expect(v.HAVPNClients).To(Equal(3))
+						Expect(v.OpenVPNNetwork).To(Equal(network.HAVPNTunnelNetwork(cfg.VPNNetwork.IP, 1)))
+						Expect(v.ShootNetworks).To(ConsistOf(v4Networks))
+						Expect(v.ShootNetworksV4).To(Equal(v.ShootNetworks))
+						Expect(v.ShootNetworksV6).To(BeEmpty())
+					})
+					It("should remove duplicates", func() {
+						cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+						cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+						cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.ShootNetworks).To(HaveLen(3))
+					})
+					Context("when networks are set (v4 + v6)", func() {
+						var v6Networks []network.CIDR
+						BeforeEach(func() {
+							v6Services := network.ParseIPNet("2001:db8:1::/64")
+							v6Pods := network.ParseIPNet("2001:db8:2::/64")
+							v6Nodes := network.ParseIPNet("2001:db8:3::/64")
+							cfg.ServiceNetworks = append(cfg.ServiceNetworks, v6Services)
+							cfg.PodNetworks = append(cfg.PodNetworks, v6Pods)
+							cfg.NodeNetworks = append(cfg.NodeNetworks, v6Nodes)
+							v6Networks = append(v6Networks, v6Services, v6Pods, v6Nodes)
+						})
+						It("should configure HA VPN correctly (v4 + v6)", func() {
+							v, err := vpn_server.BuildValues(cfg)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(v.IsHA).To(BeTrue())
+							Expect(v.VPNIndex).To(Equal(1))
+							Expect(v.Device).To(Equal(constants.TapDevice))
+							Expect(v.HAVPNClients).To(Equal(3))
+							Expect(v.OpenVPNNetwork).To(Equal(network.HAVPNTunnelNetwork(cfg.VPNNetwork.IP, 1)))
+							Expect(v.ShootNetworks).To(ConsistOf(slices.Concat(v4Networks, v6Networks)))
+							Expect(v.ShootNetworksV4).To(Equal(v4Networks))
+							Expect(v.ShootNetworksV6).To(Equal(v6Networks))
+						})
+						It("should remove duplicates", func() {
+							cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+							cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+							cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+							v, err := vpn_server.BuildValues(cfg)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(v.ShootNetworks).To(HaveLen(6))
+						})
+					})
+				})
+				Context("when networks are set (v6)", func() {
+					var v6Networks []network.CIDR
+					BeforeEach(func() {
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("2001:db8:1::/64")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("2001:db8:2::/64")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("2001:db8:3::/64")}
+						v6Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
+					})
+					It("should configure HA VPN correctly (v6)", func() {
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.IsHA).To(BeTrue())
+						Expect(v.VPNIndex).To(Equal(1))
+						Expect(v.Device).To(Equal(constants.TapDevice))
+						Expect(v.HAVPNClients).To(Equal(3))
+						Expect(v.OpenVPNNetwork).To(Equal(network.HAVPNTunnelNetwork(cfg.VPNNetwork.IP, 1)))
+						Expect(v.ShootNetworks).To(ConsistOf(v6Networks))
+						Expect(v.ShootNetworksV6).To(Equal(v.ShootNetworks))
+						Expect(v.ShootNetworksV4).To(BeEmpty())
+					})
+					It("should remove duplicates", func() {
+						cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+						cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+						cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.ShootNetworks).To(HaveLen(3))
+					})
+				})
+			})
+		})
+	})
+
+	Describe("non-HA", func() {
+		BeforeEach(func() {
+			cfg.VPNNetwork = network.ParseIPNet("2001:db8::/96")
+		})
+		Context("when IS_HA is not set", func() {
+			It("should be false", func() {
+				v, err := vpn_server.BuildValues(cfg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(v.IsHA).To(BeFalse())
+			})
+		})
+		Context("when IS_HA is set to false", func() {
+			BeforeEach(func() {
+				cfg.IsHA = false
+			})
+			It("should be false", func() {
+				v, err := vpn_server.BuildValues(cfg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(v.IsHA).To(BeFalse())
+			})
+			Context("when pod name is set stateful", func() {
+				BeforeEach(func() {
+					cfg.PodName = "vpn-seed-server-0"
+				})
+				It("should fail", func() {
+					_, err := vpn_server.BuildValues(cfg)
+					Expect(err).To(MatchError("IS_HA flag in config does not match HA info from pod name: IS_HA = false, POD_NAME = vpn-seed-server-0"))
+				})
+			})
+			Context("when pod name is set non-stateful", func() {
+				BeforeEach(func() {
+					cfg.PodName = "vpn-seed-server-5d99b56fcb-2h58x"
+				})
+				It("should pass", func() {
+					_, err := vpn_server.BuildValues(cfg)
+					Expect(err).ToNot(HaveOccurred())
+				})
+				Context("when networks are set (v4)", func() {
+					var v4NetworksMapped []network.CIDR
+					BeforeEach(func() {
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("100.80.0.0/16")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("100.81.0.0/16")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("100.82.0.0/16")}
+						v4NetworksMapped = []network.CIDR{
+							network.ParseIPNet(constants.ShootNodeNetworkMapped),
+							network.ParseIPNet(constants.ShootSvcNetworkMapped),
+							network.ParseIPNet(constants.ShootPodNetworkMapped),
+						}
+					})
+					It("should configure HA VPN correctly (v4)", func() {
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.IsHA).To(BeFalse())
+						Expect(v.VPNIndex).To(Equal(0))
+						Expect(v.Device).To(Equal(constants.TunnelDevice))
+						Expect(v.HAVPNClients).To(Equal(-1))
+						Expect(v.OpenVPNNetwork).To(Equal(cfg.VPNNetwork))
+						Expect(v.ShootNetworks).To(ConsistOf(v4NetworksMapped))
+						Expect(v.ShootNetworksV4).To(Equal(v.ShootNetworks))
+						Expect(v.ShootNetworksV6).To(BeEmpty())
+					})
+					It("should remove duplicates", func() {
+						cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+						cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+						cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.ShootNetworks).To(HaveLen(3))
+					})
+					Context("when networks are set (v4 + v6)", func() {
+						var v6Networks []network.CIDR
+						BeforeEach(func() {
+							v6Services := network.ParseIPNet("2001:db8:1::/64")
+							v6Pods := network.ParseIPNet("2001:db8:2::/64")
+							v6Nodes := network.ParseIPNet("2001:db8:3::/64")
+							cfg.ServiceNetworks = append(cfg.ServiceNetworks, v6Services)
+							cfg.PodNetworks = append(cfg.PodNetworks, v6Pods)
+							cfg.NodeNetworks = append(cfg.NodeNetworks, v6Nodes)
+							v6Networks = append(v6Networks, v6Services, v6Pods, v6Nodes)
+						})
+						It("should configure HA VPN correctly (v4 + v6)", func() {
+							v, err := vpn_server.BuildValues(cfg)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(v.IsHA).To(BeFalse())
+							Expect(v.VPNIndex).To(Equal(0))
+							Expect(v.Device).To(Equal(constants.TunnelDevice))
+							Expect(v.HAVPNClients).To(Equal(-1))
+							Expect(v.OpenVPNNetwork).To(Equal(cfg.VPNNetwork))
+							Expect(v.ShootNetworks).To(ConsistOf(slices.Concat(v4NetworksMapped, v6Networks)))
+							Expect(v.ShootNetworksV4).To(Equal(v4NetworksMapped))
+							Expect(v.ShootNetworksV6).To(Equal(v6Networks))
+						})
+						It("should remove duplicates", func() {
+							cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+							cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+							cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+							v, err := vpn_server.BuildValues(cfg)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(v.ShootNetworks).To(HaveLen(6))
+						})
+					})
+				})
+				Context("when networks are set (v6)", func() {
+					var v6Networks []network.CIDR
+					BeforeEach(func() {
+						cfg.ServiceNetworks = []network.CIDR{network.ParseIPNet("2001:db8:1::/64")}
+						cfg.PodNetworks = []network.CIDR{network.ParseIPNet("2001:db8:2::/64")}
+						cfg.NodeNetworks = []network.CIDR{network.ParseIPNet("2001:db8:3::/64")}
+						v6Networks = slices.Concat(cfg.ServiceNetworks, cfg.PodNetworks, cfg.NodeNetworks)
+					})
+					It("should configure HA VPN correctly (v6)", func() {
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.IsHA).To(BeFalse())
+						Expect(v.VPNIndex).To(Equal(0))
+						Expect(v.Device).To(Equal(constants.TunnelDevice))
+						Expect(v.HAVPNClients).To(Equal(-1))
+						Expect(v.OpenVPNNetwork).To(Equal(cfg.VPNNetwork))
+						Expect(v.ShootNetworks).To(ConsistOf(v6Networks))
+						Expect(v.ShootNetworksV6).To(Equal(v.ShootNetworks))
+						Expect(v.ShootNetworksV4).To(BeEmpty())
+					})
+					It("should remove duplicates", func() {
+						cfg.ServiceNetworks = append(cfg.ServiceNetworks, cfg.ServiceNetworks...)
+						cfg.PodNetworks = append(cfg.PodNetworks, cfg.PodNetworks...)
+						cfg.NodeNetworks = append(cfg.NodeNetworks, cfg.NodeNetworks...)
+						v, err := vpn_server.BuildValues(cfg)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(v.ShootNetworks).To(HaveLen(3))
+					})
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This change allows overlapping CIDR ranges between seed and shoot IPv4 networks for non-HA VPN deployments.

This is achieved by NAT-ing the respective networks to different subnets of the reserved 240/4 range:

seed pods => 241/8
shoot nodes => 242/8
shoot services => 243/8
shoot pods => 244/8 

This way, both seed and shoot can have e.g. the same pod range.

This currently only works for non-HA VPN because I'm using an iptables rule based on the user id of the non-root envoy process (65532) which doesn't exist for HA VPN.

**Special notes for your reviewer**:
This is a companion PR that requires additional changes to gardener/gardener.
The g/g PR can be found [here](https://github.com/gardener/gardener/pull/11582)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Overlapping CIDR ranges between seed and shoot IPv4 networks for non-HA VPN deployments are now possible.
```
