### PR TITLE
fix: validation variants of init/shoot/apiserver cases

### DIFF
--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -66,11 +66,16 @@ func GetVPNClientConfig() (VPNClient, error) {
 	cfg.VPNClientIndex = -1
 
 	if cfg.IsHA {
-		if cfg.PodName == "" {
-			return VPNClient{}, fmt.Errorf("IS_HA is set to true but POD_NAME is not set")
+		if cfg.IsShootClient {
+			if cfg.PodName == "" {
+				return VPNClient{}, fmt.Errorf("IS_HA and IS_SHOOT_CLIENT are set to true but POD_NAME is not set")
+			}
 		}
-		if cfg.VPNServerIndex == "" {
-			return VPNClient{}, fmt.Errorf("IS_HA is set to true but VPN_SERVER_INDEX is not set")
+		if cfg.HAVPNServers > 0 && cfg.HAVPNClients == 0 {
+			return VPNClient{}, fmt.Errorf("HA_VPN_SERVERS is set to %d but HA_VPN_CLIENTS is set to 0", cfg.HAVPNServers)
+		}
+		if cfg.HAVPNClients > 0 && cfg.HAVPNServers == 0 {
+			return VPNClient{}, fmt.Errorf("HA_VPN_CLIENTS is set to %d but HA_VPN_SERVERS is set to 0", cfg.HAVPNClients)
 		}
 	}
 

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -109,32 +109,47 @@ var _ = Describe("GetVPNClientConfig", func() {
 		}),
 		Entry("invalid HA configuration should fail", testCase{
 			envVars: map[string]string{
-				"IS_HA":            "banana",
-				"VPN_SERVER_INDEX": "",
-				"POD_NAME":         "",
+				"IS_HA":    "banana",
+				"POD_NAME": "",
 			},
 			expectedError: true,
 		}),
-		Entry("HA configuration should fail if POD_NAME is missing", testCase{
+		Entry("HA configuration should fail if POD_NAME is missing (IS_SHOOT_CLIENT is true)", testCase{
 			envVars: map[string]string{
-				"IS_HA":            "true",
-				"VPN_SERVER_INDEX": "1",
-				"POD_NAME":         "",
+				"IS_HA":    "true",
+				"POD_NAME": "",
 			},
 			expectedError: true,
 		}),
-		Entry("HA configuration should fail if VPN_SERVER_INDEX is missing", testCase{
+		Entry("HA configuration if POD_NAME is missing (IS_SHOOT_CLIENT is false)", testCase{
 			envVars: map[string]string{
-				"IS_HA":            "true",
-				"VPN_SERVER_INDEX": "",
-				"POD_NAME":         "test-pod-1",
+				"IS_HA":           "true",
+				"IS_SHOOT_CLIENT": "false",
+				"POD_NAME":        "",
+			},
+			expectedError: false,
+		}),
+		Entry("HA configuration should fail if HA_VPN_SERVERS is missing", testCase{
+			envVars: map[string]string{
+				"IS_HA":          "true",
+				"POD_NAME":       "test-pod-1",
+				"HA_VPN_SERVERS": "",
 			},
 			expectedError: true,
 		}),
-		Entry("non-HA configuration should not require VPN_SERVER_INDEX", testCase{
+		Entry("HA configuration should fail if HA_VPN_CLIENTS is missing", testCase{
 			envVars: map[string]string{
-				"IS_HA":            "false",
-				"VPN_SERVER_INDEX": "",
+				"IS_HA":          "true",
+				"POD_NAME":       "test-pod-1",
+				"HA_VPN_CLIENTS": "",
+			},
+			expectedError: true,
+		}),
+		Entry("non-HA configuration should not require HA_VPN_SERVERS or HA_VPN_CLIENTS", testCase{
+			envVars: map[string]string{
+				"IS_HA":          "false",
+				"HA_VPN_SERVERS": "",
+				"HA_VPN_CLIENTS": "",
 			},
 			expectedError: false,
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:

Hotfix of v0.37.0 release. This is the fix for the master branch.

HA VPN runs vpn_client in three different variants:
- init container
- regular container in shoot (IS_SHOOT_CLIENT = true)
- kube-apiserver in seed (IS_SHOOT_CLIENT not set (= false))

The previous checks did not account for the kube-apiserver variant and failed to validate. This is fixed by this PR.

**Special notes for your reviewer**:

- We also need to patch the existing 0.37.0 release to 0.37.1 [pipeline job](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/vpn2-release-v0.37)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
NONE
```
