### PR TITLE
fix: check if seed pod range is ipv4

### DIFF
--- a/cmd/vpn_server/app/firewall.go
+++ b/cmd/vpn_server/app/firewall.go
@@ -95,13 +95,16 @@ func runFirewallCommand(log logr.Logger, device, mode string, networks []string,
 	}
 
 	if device == constants.TunnelDevice {
-		err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetworkV4)
-		if err != nil {
-			return err
-		}
-		err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetworkV4, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
-		if err != nil {
-			return err
+		cidr, err := network.ParseIPNet(seedPodNetworkV4)
+		if err == nil && cidr.IsIPv4() {
+			err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetworkV4)
+			if err != nil {
+				return err
+			}
+			err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetworkV4, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

g/g e2e tests have a test where an IPv6 seed is used, even though such seeds don't yet exist in reality.

the code made the wrong assumption that the seed's spec for pod range would always be ipv4, which caused the e2e ipv6 test to fail.

this PR double-checks the seed pod range and only applies iptables rules accordingly.
this check existed [on the client](https://github.com/gardener/vpn2/blob/master/cmd/vpn_client/app/app.go#L75) side but was missing on the server side until now.

**Special notes for your reviewer**:
- We need to cherry-pick this fix to the 0.37 release branch

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
NONE
```
