### PR TITLE
fix: rename SeedPodNetworkV4 to SeedPodNetwork

### DIFF
--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -64,7 +64,7 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		VPNClientIndex:    cfg.VPNClientIndex,
 		IsShootClient:     cfg.IsShootClient,
 		IsHA:              cfg.IsHA,
-		SeedPodNetworkV4:  cfg.SeedPodNetworkV4.String(),
+		SeedPodNetwork:    cfg.SeedPodNetwork.String(),
 	}
 	vpnSeedServer := "vpn-seed-server"
 
@@ -72,8 +72,8 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		v.IsDualStack = true
 	}
 
-	if !cfg.IsHA && cfg.SeedPodNetworkV4.IsIPv4() {
-		v.SeedPodNetworkV4 = constants.SeedPodNetworkMapped
+	if !cfg.IsHA && cfg.SeedPodNetwork.IsIPv4() {
+		v.SeedPodNetwork = constants.SeedPodNetworkMapped
 	}
 
 	if cfg.VPNServerIndex != "" {

--- a/cmd/vpn_server/app/firewall.go
+++ b/cmd/vpn_server/app/firewall.go
@@ -23,10 +23,10 @@ import (
 
 func firewallCommand() *cobra.Command {
 	var (
-		device           string
-		mode             string
-		shootNetworks    []string
-		seedPodNetworkV4 string
+		device         string
+		mode           string
+		shootNetworks  []string
+		seedPodNetwork string
 	)
 
 	cmd := &cobra.Command{
@@ -38,20 +38,20 @@ func firewallCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runFirewallCommand(log, device, mode, shootNetworks, seedPodNetworkV4)
+			return runFirewallCommand(log, device, mode, shootNetworks, seedPodNetwork)
 		},
 	}
 
 	cmd.Flags().StringVar(&device, "device", "", "device to configure")
 	cmd.Flags().StringVar(&mode, "mode", "", "mode of firewall (up or down)")
 	cmd.Flags().StringSliceVar(&shootNetworks, "shoot-network", nil, "shoot networks to add routes for")
-	cmd.Flags().StringVar(&seedPodNetworkV4, "seed-pod-network-v4", "", "ipv4 seed pod network to add double-nat mapping rules for")
+	cmd.Flags().StringVar(&seedPodNetwork, "seed-pod-network", "", "seed pod network to add double-nat mapping rules for (IPv4 only)")
 	cmd.MarkFlagsRequiredTogether("device", "mode")
 
 	return cmd
 }
 
-func runFirewallCommand(log logr.Logger, device, mode string, networks []string, seedPodNetworkV4 string) error {
+func runFirewallCommand(log logr.Logger, device, mode string, networks []string, seedPodNetwork string) error {
 	// Firewall subcommand is called indirectly from openvpn. As PATH env variables seems not to be set,
 	// it is injected here.
 	if err := os.Setenv("PATH", "/sbin"); err != nil {
@@ -95,13 +95,13 @@ func runFirewallCommand(log logr.Logger, device, mode string, networks []string,
 	}
 
 	if device == constants.TunnelDevice {
-		cidr, err := network.ParseIPNet(seedPodNetworkV4)
+		cidr, err := network.ParseIPNet(seedPodNetwork)
 		if err == nil && cidr.IsIPv4() {
-			err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetworkV4)
+			err = op4("nat", "PREROUTING", "--in-interface", device, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", seedPodNetwork)
 			if err != nil {
 				return err
 			}
-			err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetworkV4, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
+			err = op4("nat", "POSTROUTING", "--out-interface", device, "-s", seedPodNetwork, "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
 			if err != nil {
 				return err
 			}

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -27,7 +27,7 @@ type VPNClient struct {
 	Endpoint             string         `env:"ENDPOINT"`
 	OpenVPNPort          uint           `env:"OPENVPN_PORT" envDefault:"8132"`
 	VPNNetwork           network.CIDR   `env:"VPN_NETWORK"`
-	SeedPodNetworkV4     network.CIDR   `env:"SEED_POD_NETWORK_V4"`
+	SeedPodNetwork       network.CIDR   `env:"SEED_POD_NETWORK"`
 	ShootServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS"`
 	ShootPodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS"`
 	ShootNodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -30,7 +30,7 @@ var _ = Describe("GetVPNClientConfig", func() {
 			"ENDPOINT":               "endpoint",
 			"OPENVPN_PORT":           "8132",
 			"VPN_NETWORK":            "fd8f:6d53:b97a:1::/96",
-			"SEED_POD_NETWORK_V4":    "10.0.0.0/8",
+			"SEED_POD_NETWORK":       "10.0.0.0/8",
 			"SHOOT_SERVICE_NETWORKS": "100.64.0.0/13",
 			"SHOOT_POD_NETWORKS":     "100.96.0.0/11",
 			"SHOOT_NODE_NETWORKS":    "100.128.0.0/10",
@@ -56,7 +56,7 @@ var _ = Describe("GetVPNClientConfig", func() {
 		Expect(os.Unsetenv("ENDPOINT")).To(Succeed())
 		Expect(os.Unsetenv("OPENVPN_PORT")).To(Succeed())
 		Expect(os.Unsetenv("VPN_NETWORK")).To(Succeed())
-		Expect(os.Unsetenv("SEED_POD_NETWORK_V4")).To(Succeed())
+		Expect(os.Unsetenv("SEED_POD_NETWORK")).To(Succeed())
 		Expect(os.Unsetenv("SHOOT_SERVICE_NETWORKS")).To(Succeed())
 		Expect(os.Unsetenv("SHOOT_POD_NETWORKS")).To(Succeed())
 		Expect(os.Unsetenv("SHOOT_NODE_NETWORKS")).To(Succeed())
@@ -253,7 +253,7 @@ var _ = Describe("GetVPNClientConfig", func() {
 		}),
 		Entry("multiple seed pod networks should fail", testCase{
 			envVars: map[string]string{
-				"SEED_POD_NETWORK_V4": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
+				"SEED_POD_NETWORK": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
 			},
 			expectedError: true,
 		}),

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -14,16 +14,16 @@ import (
 )
 
 type VPNServer struct {
-	ServiceNetworks  []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
-	PodNetworks      []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
-	NodeNetworks     []network.CIDR `env:"NODE_NETWORKS"`
-	VPNNetwork       network.CIDR   `env:"VPN_NETWORK"`
-	SeedPodNetworkV4 network.CIDR   `env:"SEED_POD_NETWORK_V4"`
-	PodName          string         `env:"POD_NAME"`
-	StatusPath       string         `env:"OPENVPN_STATUS_PATH"`
-	IsHA             bool           `env:"IS_HA"`
-	HAVPNClients     int            `env:"HA_VPN_CLIENTS"`
-	LocalNodeIP      string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
+	ServiceNetworks []network.CIDR `env:"SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
+	PodNetworks     []network.CIDR `env:"POD_NETWORKS" envDefault:"100.96.0.0/11"`
+	NodeNetworks    []network.CIDR `env:"NODE_NETWORKS"`
+	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
+	SeedPodNetwork  network.CIDR   `env:"SEED_POD_NETWORK"`
+	PodName         string         `env:"POD_NAME"`
+	StatusPath      string         `env:"OPENVPN_STATUS_PATH"`
+	IsHA            bool           `env:"IS_HA"`
+	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
+	LocalNodeIP     string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/config/vpn-server_test.go
+++ b/pkg/config/vpn-server_test.go
@@ -34,7 +34,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 			"POD_NETWORKS":        "100.96.0.0/11",
 			"NODE_NETWORKS":       "100.128.0.0/10",
 			"VPN_NETWORK":         "fd8f:6d53:b97a:1::/96",
-			"SEED_POD_NETWORK_V4": "10.0.0.0/8",
+			"SEED_POD_NETWORK":    "10.0.0.0/8",
 			"POD_NAME":            "test-pod",
 			"OPENVPN_STATUS_PATH": "/status",
 			"IS_HA":               "true",
@@ -49,7 +49,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 		Expect(os.Unsetenv("POD_NETWORKS")).To(Succeed())
 		Expect(os.Unsetenv("NODE_NETWORKS")).To(Succeed())
 		Expect(os.Unsetenv("VPN_NETWORK")).To(Succeed())
-		Expect(os.Unsetenv("SEED_POD_NETWORK_V4")).To(Succeed())
+		Expect(os.Unsetenv("SEED_POD_NETWORK")).To(Succeed())
 		Expect(os.Unsetenv("POD_NAME")).To(Succeed())
 		Expect(os.Unsetenv("OPENVPN_STATUS_PATH")).To(Succeed())
 		Expect(os.Unsetenv("IS_HA")).To(Succeed())
@@ -194,7 +194,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 		}),
 		Entry("multiple seed pod networks should fail", testCase{
 			envVars: map[string]string{
-				"SEED_POD_NETWORK_V4": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
+				"SEED_POD_NETWORK": "10.0.0.0/8,11.0.0.0/8,12.0.0.0/8",
 			},
 			expectedError: true,
 		}),

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -45,5 +45,5 @@ remote {{ .Endpoint }}
 
 {{- if and .IsShootClient (not .IsHA) }}
 script-security 2
-up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetworkV4 }} dev $1' -- "
+up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
 {{- end }}

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -41,7 +41,7 @@ dev {{ .Device }}
 {{/* Add firewall rules to block all traffic originating from the shoot cluster.
      The scripts are run after the tun device has been created (up) or removed (down). */ -}}
 script-security 2
-up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }} --seed-pod-network-v4={{ .SeedPodNetworkV4 }}"
+up "/bin/vpn-server firewall --mode up --device {{ .Device }} --shoot-network={{ networksToString .ShootNetworks }} --seed-pod-network={{ .SeedPodNetwork }}"
 down "/bin/vpn-server firewall --mode down --device {{ .Device }}"
 
 {{ if not (eq .StatusPath "") -}}

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -23,7 +23,7 @@ type ClientValues struct {
 	IsShootClient     bool
 	IsHA              bool
 	Device            string
-	SeedPodNetworkV4  string
+	SeedPodNetwork    string
 	IsDualStack       bool
 }
 

--- a/pkg/openvpn/config_client_test.go
+++ b/pkg/openvpn/config_client_test.go
@@ -46,7 +46,7 @@ ca /srv/secrets/vpn-client/ca.crt`))
 				OpenVPNPort:       1143,
 				ReversedVPNHeader: "invalid-host",
 				IsShootClient:     true,
-				SeedPodNetworkV4:  "10.123.0.0/19",
+				SeedPodNetwork:    "10.123.0.0/19",
 			}
 
 			content, err := generateClientConfig(cfg)
@@ -88,7 +88,7 @@ up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
 				OpenVPNPort:       1143,
 				ReversedVPNHeader: "invalid-host",
 				IsShootClient:     true,
-				SeedPodNetworkV4:  "10.123.0.0/19",
+				SeedPodNetwork:    "10.123.0.0/19",
 			}
 
 			content, err := generateClientConfig(cfg)

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -22,17 +22,17 @@ var (
 )
 
 type SeedServerValues struct {
-	Device           string
-	StatusPath       string
-	OpenVPNNetwork   network.CIDR
-	ShootNetworks    []network.CIDR
-	ShootNetworksV4  []network.CIDR
-	ShootNetworksV6  []network.CIDR
-	SeedPodNetworkV4 network.CIDR
-	HAVPNClients     int
-	IsHA             bool
-	VPNIndex         int
-	LocalNodeIP      string
+	Device          string
+	StatusPath      string
+	OpenVPNNetwork  network.CIDR
+	ShootNetworks   []network.CIDR
+	ShootNetworksV4 []network.CIDR
+	ShootNetworksV6 []network.CIDR
+	SeedPodNetwork  network.CIDR
+	HAVPNClients    int
+	IsHA            bool
+	VPNIndex        int
+	LocalNodeIP     string
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/openvpn/config_server_test.go
+++ b/pkg/openvpn/config_server_test.go
@@ -40,7 +40,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNetIgnoreError("100.96.0.0/11"),
 				network.ParseIPNetIgnoreError("10.0.1.0/24"),
 			},
-			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
+			SeedPodNetwork: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 		cfgIPv6 = SeedServerValues{
 			Device:         "tun0",
@@ -56,7 +56,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
 				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
-			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
+			SeedPodNetwork: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 		cfgDualStack = SeedServerValues{
 			Device:         "tun0",
@@ -80,7 +80,7 @@ var _ = Describe("#SeedServerConfig", func() {
 				network.ParseIPNetIgnoreError("2001:db8:2::/48"),
 				network.ParseIPNetIgnoreError("2001:db8:3::/48"),
 			},
-			SeedPodNetworkV4: network.ParseIPNetIgnoreError("100.64.0.0/12"),
+			SeedPodNetwork: network.ParseIPNetIgnoreError("100.64.0.0/12"),
 		}
 	})
 
@@ -101,7 +101,7 @@ server-ipv6 fd8f:6d53:b97a:7777::/96
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network-v4=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
@@ -129,7 +129,7 @@ dev tap0
 
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network-v4=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tap0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24 --seed-pod-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tap0"`))
 
 			Expect(content).To(ContainSubstring(`
@@ -153,7 +153,7 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network-v4=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})
@@ -173,7 +173,7 @@ dev tun0
 `))
 			Expect(content).To(ContainSubstring(`
 script-security 2
-up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network-v4=100.64.0.0/12"
+up "/bin/vpn-server firewall --mode up --device tun0 --shoot-network=100.64.0.0/13,100.96.0.0/11,10.0.1.0/24,2001:db8:1::/48,2001:db8:2::/48,2001:db8:3::/48 --seed-pod-network=100.64.0.0/12"
 down "/bin/vpn-server firewall --mode down --device tun0"`))
 			Expect(content).To(HaveNoLineLongerThan(OpenVPNConfigMaxLineLength))
 		})

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -54,7 +54,7 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		v.HAVPNClients = -1
 		v.OpenVPNNetwork = cfg.VPNNetwork
 
-		v.SeedPodNetworkV4 = cfg.SeedPodNetworkV4
+		v.SeedPodNetwork = cfg.SeedPodNetwork
 		// IPv4 networks are mapped to 240/4, IPv6 networks are kept as is
 		for _, serviceNetwork := range cfg.ServiceNetworks {
 			if serviceNetwork.IP.To4() != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

There was [some confusion](https://github.com/gardener/gardener/pull/11582#discussion_r2018863502) about the naming of `SeedPodNetworkV4` in a IPv6-only scenario where no IPv4 network exists on the seed.

To remove the confusion, the field was changed back to `SeedPodNetwork` and expects the spec value for the seed pod network "as-is", including a possible IPv6 range.

The logic of distinguishing IPv4 vs IPv6 networks and applying mapping for IPv4 only will be done on the VPN-side.

**Special notes for your reviewer**:
- Needs a cherry-pick to release 0.37

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
SeedPodNetworkV4 was renamed to SeedPodNetwork. IPv4 vs IPv6 discrimination is done solely on the VPN side now.
```
