### PR TITLE
fix: HA VPN: only map to 240/4 on cidr overlap

### DIFF
--- a/cmd/vpn_client/app/pathcontroller/client_router.go
+++ b/cmd/vpn_client/app/pathcontroller/client_router.go
@@ -135,17 +135,9 @@ func (r *netlinkRouter) updateRouting(newIP net.IP) error {
 		nodeNetworks    []network.CIDR
 	)
 
-	ipv4PodNetworks := network.GetByIPFamily(r.shootPodNetworks, network.IPv4Family)
-	if len(ipv4PodNetworks) > 1 {
-		return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-	}
-	ipv4ServiceNetworks := network.GetByIPFamily(r.shootServiceNetworks, network.IPv4Family)
-	if len(ipv4ServiceNetworks) > 1 {
-		return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-	}
-	ipv4NodeNetworks := network.GetByIPFamily(r.shootNodeNetworks, network.IPv4Family)
-	if len(ipv4NodeNetworks) > 1 {
-		return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+	_, _, _, err = network.ShootNetworksForNetmap(r.shootPodNetworks, r.shootServiceNetworks, r.shootNodeNetworks)
+	if err != nil {
+		return err
 	}
 
 	// Check if there is an overlap between the seed pod network and shoot networks.

--- a/pkg/config/pathcontroller.go
+++ b/pkg/config/pathcontroller.go
@@ -14,12 +14,13 @@ import (
 )
 
 type PathController struct {
-	IPFamilies      string         `env:"IP_FAMILIES" envDefault:"IPv4"`
-	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
-	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
-	ServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
-	PodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS" envDefault:"100.96.0.0/11"`
-	NodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`
+	IPFamilies           string         `env:"IP_FAMILIES" envDefault:"IPv4"`
+	VPNNetwork           network.CIDR   `env:"VPN_NETWORK"`
+	HAVPNClients         int            `env:"HA_VPN_CLIENTS"`
+	ShootServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
+	ShootPodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS" envDefault:"100.96.0.0/11"`
+	ShootNodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`
+	SeedPodNetwork       network.CIDR   `env:"SEED_POD_NETWORK"`
 }
 
 func (v PathController) PrimaryIPFamily() string {

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -14,16 +14,16 @@ import (
 )
 
 type VPNServer struct {
-	ServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
-	PodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS" envDefault:"100.96.0.0/11"`
-	NodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`
-	VPNNetwork      network.CIDR   `env:"VPN_NETWORK"`
-	SeedPodNetwork  network.CIDR   `env:"SEED_POD_NETWORK"`
-	PodName         string         `env:"POD_NAME"`
-	StatusPath      string         `env:"OPENVPN_STATUS_PATH"`
-	IsHA            bool           `env:"IS_HA"`
-	HAVPNClients    int            `env:"HA_VPN_CLIENTS"`
-	LocalNodeIP     string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
+	ShootServiceNetworks []network.CIDR `env:"SHOOT_SERVICE_NETWORKS" envDefault:"100.64.0.0/13"`
+	ShootPodNetworks     []network.CIDR `env:"SHOOT_POD_NETWORKS" envDefault:"100.96.0.0/11"`
+	ShootNodeNetworks    []network.CIDR `env:"SHOOT_NODE_NETWORKS"`
+	VPNNetwork           network.CIDR   `env:"VPN_NETWORK"`
+	SeedPodNetwork       network.CIDR   `env:"SEED_POD_NETWORK"`
+	PodName              string         `env:"POD_NAME"`
+	StatusPath           string         `env:"OPENVPN_STATUS_PATH"`
+	IsHA                 bool           `env:"IS_HA"`
+	HAVPNClients         int            `env:"HA_VPN_CLIENTS"`
+	LocalNodeIP          string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/config/vpn-server_test.go
+++ b/pkg/config/vpn-server_test.go
@@ -164,7 +164,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 				"SHOOT_POD_NETWORKS": "100.96.0.0/11,100.97.0.0/11,100.98.0.0/11",
 			},
 			expectedMatcher: MatchFields(IgnoreExtras, Fields{
-				"PodNetworks": ConsistOf(
+				"ShootPodNetworks": ConsistOf(
 					network.ParseIPNetIgnoreError("100.96.0.0/11"),
 					network.ParseIPNetIgnoreError("100.97.0.0/11"),
 					network.ParseIPNetIgnoreError("100.98.0.0/11")),
@@ -175,7 +175,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 				"SHOOT_SERVICE_NETWORKS": "100.64.0.0/13,100.65.0.0/13,100.66.0.0/13",
 			},
 			expectedMatcher: MatchFields(IgnoreExtras, Fields{
-				"ServiceNetworks": ConsistOf(
+				"ShootServiceNetworks": ConsistOf(
 					network.ParseIPNetIgnoreError("100.64.0.0/13"),
 					network.ParseIPNetIgnoreError("100.65.0.0/13"),
 					network.ParseIPNetIgnoreError("100.66.0.0/13")),
@@ -186,7 +186,7 @@ var _ = Describe("GetVPNServerConfig", func() {
 				"SHOOT_NODE_NETWORKS": "100.128.0.0/10,101.128.0.0/10,102.128.0.0/10",
 			},
 			expectedMatcher: MatchFields(IgnoreExtras, Fields{
-				"NodeNetworks": ConsistOf(
+				"ShootNodeNetworks": ConsistOf(
 					network.ParseIPNetIgnoreError("100.128.0.0/10"),
 					network.ParseIPNetIgnoreError("101.128.0.0/10"),
 					network.ParseIPNetIgnoreError("102.128.0.0/10")),

--- a/pkg/network/iptables.go
+++ b/pkg/network/iptables.go
@@ -37,3 +37,22 @@ func iptablesWorks(path string) bool {
 	// check both iptables and ip6tables
 	return exec.Command(path, "-L").Run() == nil && exec.Command(adjustPath(path, iptables.ProtocolIPv6), "-L").Run() == nil // #nosec: G204 -- Command line is completely static "/usr/sbin/(iptables|ip6tables)-(legacy|nft) -L".
 }
+
+// ShootNetworksForNetmap verifies that there is exactly one IPv4 pod, service, and node network in the provided lists.
+// This is needed until more than one network is supported in the netmap iptables rules and more can be defined in the shoot spec.
+// The function returns the IPv4 networks or an error if the requirements are not met.
+func ShootNetworksForNetmap(ShootPodNetworks, ShootServiceNetworks, ShootNodeNetworks []CIDR) (ipv4PodNetworks []CIDR, ipv4ServiceNetworks []CIDR, ipv4NodeNetworks []CIDR, err error) {
+	ipv4PodNetworks = GetByIPFamily(ShootPodNetworks, IPv4Family)
+	if len(ipv4PodNetworks) > 1 {
+		return nil, nil, nil, fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
+	}
+	ipv4ServiceNetworks = GetByIPFamily(ShootServiceNetworks, IPv4Family)
+	if len(ipv4ServiceNetworks) > 1 {
+		return nil, nil, nil, fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
+	}
+	ipv4NodeNetworks = GetByIPFamily(ShootNodeNetworks, IPv4Family)
+	if len(ipv4NodeNetworks) > 1 {
+		return nil, nil, nil, fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+	}
+	return ipv4PodNetworks, ipv4ServiceNetworks, ipv4NodeNetworks, nil
+}

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -84,3 +84,18 @@ func GetByIPFamily(cidrs []CIDR, ipFamily string) []CIDR {
 	}
 	return result
 }
+
+// Overlap checks if two IP networks overlap.
+func Overlap(a, b CIDR) bool {
+	return a.ToIPNet().Contains(b.IP) || b.ToIPNet().Contains(a.IP)
+}
+
+// OverLapAny checks if any of the given IP networks otherNws overlap with nw.
+func OverLapAny(nw CIDR, otherNws ...CIDR) bool {
+	for _, otherNw := range otherNws {
+		if Overlap(nw, otherNw) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -45,17 +45,9 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				}
 				if !cfg.IsHA || cfg.IsHA && overlap {
 					log.Info("setting up double NAT IPv4 iptables rules (shoot)")
-					ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
-					if len(ipv4PodNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-					}
-					ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
-					if len(ipv4ServiceNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-					}
-					ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
-					if len(ipv4NodeNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+					ipv4PodNetworks, ipv4ServiceNetworks, ipv4NodeNetworks, err := network.ShootNetworksForNetmap(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks)
+					if err != nil {
+						return err
 					}
 
 					for _, nw := range ipv4PodNetworks {
@@ -110,17 +102,9 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 						return err
 					}
 
-					ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
-					if len(ipv4PodNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-					}
-					ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
-					if len(ipv4ServiceNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-					}
-					ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
-					if len(ipv4NodeNetworks) > 1 {
-						return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+					ipv4PodNetworks, ipv4ServiceNetworks, ipv4NodeNetworks, err := network.ShootNetworksForNetmap(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks)
+					if err != nil {
+						return err
 					}
 
 					for _, nw := range ipv4PodNetworks {

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -6,6 +6,7 @@ package vpn_client
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -23,6 +24,9 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 		forwardDevice = fmt.Sprintf("%s+", constants.BondDevice)
 	}
 
+	// In HA mode, we only set up double NAT rules if there is an overlap between the seed pod network and the shoot networks.
+	overlap := network.OverLapAny(cfg.SeedPodNetwork, slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks)...)
+
 	for _, family := range cfg.IPFamilies {
 		protocol := iptables.ProtocolIPv4
 		if family == constants.IPv6Family {
@@ -39,48 +43,50 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				if err != nil {
 					return err
 				}
-				log.Info("setting up double NAT IPv4 iptables rules (shoot)")
-				ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
-				if len(ipv4PodNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-				}
-				ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
-				if len(ipv4ServiceNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-				}
-				ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
-				if len(ipv4NodeNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
-				}
+				if !cfg.IsHA || cfg.IsHA && overlap {
+					log.Info("setting up double NAT IPv4 iptables rules (shoot)")
+					ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
+					if len(ipv4PodNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
+					}
+					ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
+					if len(ipv4ServiceNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
+					}
+					ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
+					if len(ipv4NodeNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+					}
 
-				for _, nw := range ipv4PodNetworks {
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", nw.String())
-					if err != nil {
-						return err
+					for _, nw := range ipv4PodNetworks {
+						err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootPodNetworkMapped, "-j", "NETMAP", "--to", nw.String())
+						if err != nil {
+							return err
+						}
+						err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
-					if err != nil {
-						return err
+					for _, nw := range ipv4ServiceNetworks {
+						err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootServiceNetworkMapped, "-j", "NETMAP", "--to", nw.String())
+						if err != nil {
+							return err
+						}
+						err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
-				}
-				for _, nw := range ipv4ServiceNetworks {
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootServiceNetworkMapped, "-j", "NETMAP", "--to", nw.String())
-					if err != nil {
-						return err
-					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
-					if err != nil {
-						return err
-					}
-				}
-				for _, nw := range ipv4NodeNetworks {
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", nw.String())
-					if err != nil {
-						return err
-					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
-					if err != nil {
-						return err
+					for _, nw := range ipv4NodeNetworks {
+						err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.ShootNodeNetworkMapped, "-j", "NETMAP", "--to", nw.String())
+						if err != nil {
+							return err
+						}
+						err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -96,52 +102,55 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 			}
 		} else {
 			if protocol == iptables.ProtocolIPv4 {
-				log.Info("setting up double NAT IPv4 iptables rules (seed)")
-				ipTable, err := network.NewIPTables(log, iptables.ProtocolIPv4)
-				if err != nil {
-					return err
-				}
+				// Seed client only exists in HA VPN mode, so we don't need to check for IsHA
+				if overlap {
+					log.Info("setting up double NAT IPv4 iptables rules (seed)")
+					ipTable, err := network.NewIPTables(log, iptables.ProtocolIPv4)
+					if err != nil {
+						return err
+					}
 
-				ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
-				if len(ipv4PodNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-				}
-				ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
-				if len(ipv4ServiceNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-				}
-				ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
-				if len(ipv4NodeNetworks) > 1 {
-					return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
-				}
+					ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
+					if len(ipv4PodNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
+					}
+					ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
+					if len(ipv4ServiceNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
+					}
+					ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
+					if len(ipv4NodeNetworks) > 1 {
+						return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+					}
 
-				for _, nw := range ipv4PodNetworks {
-					err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
-					if err != nil {
-						return err
+					for _, nw := range ipv4PodNetworks {
+						err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootPodNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
-				}
-				for _, nw := range ipv4ServiceNetworks {
-					err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
-					if err != nil {
-						return err
+					for _, nw := range ipv4ServiceNetworks {
+						err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootServiceNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
-				}
-				for _, nw := range ipv4NodeNetworks {
-					err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
-					if err != nil {
-						return err
+					for _, nw := range ipv4NodeNetworks {
+						err = ipTable.AppendUnique("nat", "OUTPUT", "-m", "owner", "--gid-owner", strconv.Itoa(constants.EnvoyVPNGroupId), "-d", nw.String(), "-j", "NETMAP", "--to", constants.ShootNodeNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
-				}
 
-				if cfg.SeedPodNetwork.IsIPv4() {
-					err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", cfg.SeedPodNetwork.String())
-					if err != nil {
-						return err
-					}
-					err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.SeedPodNetwork.String(), "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
-					if err != nil {
-						return err
+					if cfg.SeedPodNetwork.IsIPv4() {
+						err = ipTable.AppendUnique("nat", "PREROUTING", "--in-interface", forwardDevice, "-d", constants.SeedPodNetworkMapped, "-j", "NETMAP", "--to", cfg.SeedPodNetwork.String())
+						if err != nil {
+							return err
+						}
+						err = ipTable.AppendUnique("nat", "POSTROUTING", "--out-interface", forwardDevice, "-s", cfg.SeedPodNetwork.String(), "-j", "NETMAP", "--to", constants.SeedPodNetworkMapped)
+						if err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/pkg/vpn_server/iptables.go
+++ b/pkg/vpn_server/iptables.go
@@ -1,7 +1,6 @@
 package vpn_server
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -20,17 +19,9 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNServer) error {
 			return err
 		}
 
-		ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
-		if len(ipv4PodNetworks) > 1 {
-			return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-		}
-		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
-		if len(ipv4ServiceNetworks) > 1 {
-			return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-		}
-		ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
-		if len(ipv4NodeNetworks) > 1 {
-			return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
+		ipv4PodNetworks, ipv4ServiceNetworks, ipv4NodeNetworks, err := network.ShootNetworksForNetmap(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks)
+		if err != nil {
+			return err
 		}
 
 		for _, nw := range ipv4PodNetworks {

--- a/pkg/vpn_server/iptables.go
+++ b/pkg/vpn_server/iptables.go
@@ -20,15 +20,15 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNServer) error {
 			return err
 		}
 
-		ipv4PodNetworks := network.GetByIPFamily(cfg.PodNetworks, network.IPv4Family)
+		ipv4PodNetworks := network.GetByIPFamily(cfg.ShootPodNetworks, network.IPv4Family)
 		if len(ipv4PodNetworks) > 1 {
 			return fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
 		}
-		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ServiceNetworks, network.IPv4Family)
+		ipv4ServiceNetworks := network.GetByIPFamily(cfg.ShootServiceNetworks, network.IPv4Family)
 		if len(ipv4ServiceNetworks) > 1 {
 			return fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
 		}
-		ipv4NodeNetworks := network.GetByIPFamily(cfg.NodeNetworks, network.IPv4Family)
+		ipv4NodeNetworks := network.GetByIPFamily(cfg.ShootNodeNetworks, network.IPv4Family)
 		if len(ipv4NodeNetworks) > 1 {
 			return fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
 		}

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -38,35 +38,42 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		return v, fmt.Errorf("IS_HA flag in config does not match HA info from pod name: IS_HA = %t, POD_NAME = %s", cfg.IsHA, cfg.PodName)
 	}
 
+	// doNetmap is used to determine if the server should use netmap rules for IPv4 networks.
+	// In non-HA mode, we always map. In HA mode, we only map if there is a network overlap.
+	doNetmap := false
 	switch v.IsHA {
 	case true:
 		v.Device = constants.TapDevice
 		v.HAVPNClients = cfg.HAVPNClients
 		v.OpenVPNNetwork = network.HAVPNTunnelNetwork(cfg.VPNNetwork.IP, v.VPNIndex)
+		if network.OverLapAny(cfg.SeedPodNetwork, slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks)...) {
+			doNetmap = true
+		}
 	case false:
 		v.Device = constants.TunnelDevice
 		v.HAVPNClients = -1
 		v.OpenVPNNetwork = cfg.VPNNetwork
+		doNetmap = true
 	}
 
 	v.SeedPodNetwork = cfg.SeedPodNetwork
 	// IPv4 networks are mapped to 240/4, IPv6 networks are kept as is
-	for _, serviceNetwork := range cfg.ServiceNetworks {
-		if serviceNetwork.IP.To4() != nil {
+	for _, serviceNetwork := range cfg.ShootServiceNetworks {
+		if serviceNetwork.IP.To4() != nil && doNetmap {
 			v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootServiceNetworkMapped))
 		} else {
 			v.ShootNetworks = append(v.ShootNetworks, serviceNetwork)
 		}
 	}
-	for _, podNetwork := range cfg.PodNetworks {
-		if podNetwork.IP.To4() != nil {
+	for _, podNetwork := range cfg.ShootPodNetworks {
+		if podNetwork.IP.To4() != nil && doNetmap {
 			v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootPodNetworkMapped))
 		} else {
 			v.ShootNetworks = append(v.ShootNetworks, podNetwork)
 		}
 	}
-	for _, nodeNetwork := range cfg.NodeNetworks {
-		if nodeNetwork.IP.To4() != nil {
+	for _, nodeNetwork := range cfg.ShootNodeNetworks {
+		if nodeNetwork.IP.To4() != nil && doNetmap {
 			v.ShootNetworks = append(v.ShootNetworks, network.ParseIPNetIgnoreError(constants.ShootNodeNetworkMapped))
 		} else {
 			v.ShootNetworks = append(v.ShootNetworks, nodeNetwork)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add special handling for the HA VPN case
  - Check if any of the shoot's IPv4 CIDR ranges overlap with the seed pod network
  - If there is any overlap, apply the 240/4 double-NAT mapping as we do for non-HA VPN
  - If there is no overlap, do not apply any double-NAT mapping, keep everything as before
- Make network range naming more explicit, e.g.: `PodNetworks` => `ShootPodNetworks` etc. 

**Special notes for your reviewer**:

This is a companion PR to [this g/g PR](https://github.com/gardener/gardener/pull/12204). Both need to be merged in this order:
1. Merge VPN PR
2. Create VPN release
3. Update [g/g PR](https://github.com/gardener/gardener/pull/12204) with new VPN release
4. Merge g/g PR

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Double-NAT IP mapping will only be done if there is an actual overlap of shoot vs. seed IPv4 network ranges for HA VPN deployments. Non-HA VPN configurations are unchanged.
```
