### PR TITLE
fix: remove obsolete tcp keepalive settings

### DIFF
--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -18,11 +18,6 @@ import (
 )
 
 type VPNClient struct {
-	TCP struct {
-		KeepAliveTime     uint64 `env:"KEEPALIVE_TIME" envDefault:"7200"`
-		KeepAliveInterval uint64 `env:"KEEPALIVE_INTVL" envDefault:"75"`
-		KeepAliveProbes   uint64 `env:"KEEPALIVE_PROBES" envDefault:"9"`
-	} `envPrefix:"TCP_"`
 	IPFamilies           []string       `env:"IP_FAMILIES" envDefault:"IPv4"`
 	Endpoint             string         `env:"ENDPOINT"`
 	OpenVPNPort          uint           `env:"OPENVPN_PORT" envDefault:"8132"`

--- a/pkg/config/vpn-client_test.go
+++ b/pkg/config/vpn-client_test.go
@@ -23,9 +23,6 @@ var _ = Describe("GetVPNClientConfig", func() {
 	BeforeEach(func() {
 		// Set default environment variables
 		defaultEnvVars = map[string]string{
-			"TCP_KEEPALIVE_TIME":     "7200",
-			"TCP_KEEPALIVE_INTVL":    "75",
-			"TCP_KEEPALIVE_PROBES":   "9",
 			"IP_FAMILIES":            "IPv4",
 			"ENDPOINT":               "endpoint",
 			"OPENVPN_PORT":           "8132",
@@ -49,9 +46,6 @@ var _ = Describe("GetVPNClientConfig", func() {
 
 	AfterEach(func() {
 		// Clean up environment variables after each test
-		Expect(os.Unsetenv("TCP_KEEPALIVE_TIME")).To(Succeed())
-		Expect(os.Unsetenv("TCP_KEEPALIVE_INTVL")).To(Succeed())
-		Expect(os.Unsetenv("TCP_KEEPALIVE_PROBES")).To(Succeed())
 		Expect(os.Unsetenv("IP_FAMILIES")).To(Succeed())
 		Expect(os.Unsetenv("ENDPOINT")).To(Succeed())
 		Expect(os.Unsetenv("OPENVPN_PORT")).To(Succeed())
@@ -165,36 +159,6 @@ var _ = Describe("GetVPNClientConfig", func() {
 				"POD_NAME": "test-pod-2",
 			},
 			expectedMatcher: MatchFields(IgnoreExtras, Fields{"VPNClientIndex": Equal(2)}),
-		}),
-		Entry("empty TCP config should yield default values", testCase{
-			envVars: map[string]string{
-				"TCP_KEEPALIVE_TIME":   "",
-				"TCP_KEEPALIVE_INTVL":  "",
-				"TCP_KEEPALIVE_PROBES": "",
-			},
-			expectedMatcher: MatchFields(IgnoreExtras, Fields{
-				"TCP": MatchFields(IgnoreExtras, Fields{
-					"KeepAliveTime":     Equal(uint64(7200)),
-					"KeepAliveInterval": Equal(uint64(75)),
-					"KeepAliveProbes":   Equal(uint64(9)),
-				}),
-			}),
-		}),
-		Entry("bad TCP config should fail", testCase{
-			envVars: map[string]string{
-				"TCP_KEEPALIVE_TIME":   "potato",
-				"TCP_KEEPALIVE_INTVL":  "banana",
-				"TCP_KEEPALIVE_PROBES": "apple",
-			},
-			expectedError: true,
-		}),
-		Entry("negative TCP config values should fail", testCase{
-			envVars: map[string]string{
-				"TCP_KEEPALIVE_TIME":   "-100",
-				"TCP_KEEPALIVE_INTVL":  "-10",
-				"TCP_KEEPALIVE_PROBES": "-30",
-			},
-			expectedError: true,
 		}),
 		Entry("empty IP_FAMILIES should yield IPv4 default", testCase{
 			envVars: map[string]string{

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -44,20 +44,5 @@ func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
 		return err
 	}
-	// Set the keepalive time for TCP connections.
-	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_time", int64(cfg.TCP.KeepAliveTime)); err != nil {
-		return err
-	}
-	// Set the keepalive interval for TCP connections.
-	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_intvl", int64(cfg.TCP.KeepAliveInterval)); err != nil {
-		return err
-	}
-	// Set the number of keepalive probes for TCP connections.
-	// #nosec: G115 -- overflow unlikely (max value 9223372036854775807 before overflow)
-	if err := sysctl.WriteInt("net.ipv4.tcp_keepalive_probes", int64(cfg.TCP.KeepAliveProbes)); err != nil {
-		return err
-	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- I've noticed very high default tcp keepalive settings (KeepAliveTime at 2h)
- These defaults are never set in g/g to more meaningful values
- The very high default of 2h before the first tcp keepalive is sent, will prevent tpcka from ever working in a real deployment
- At the same time, we already have keepalive set [at the vpn level](https://github.com/gardener/vpn2/blob/master/pkg/openvpn/assets/server-config.template#L15) which sends a (openvpn) keepalive packet via UDP every 10s and should be enough to keep the connection alive
- To keep things simple and remove obsolete knobs and dials, I've opted to remove the kernel tcpka settings and only keep the openvpn settings


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Unused tcp keepalive settings have been removed in favor of openvpn keepalive
```
