### PR TITLE
feat: allow multiple ipv4 subnets be mapped to 240/4 NAT ranges

### DIFF
--- a/cmd/vpn_client/app/pathcontroller/client_router.go
+++ b/cmd/vpn_client/app/pathcontroller/client_router.go
@@ -135,6 +135,7 @@ func (r *netlinkRouter) updateRouting(newIP net.IP) error {
 		nodeNetworks    []network.CIDR
 	)
 
+	// we don't need the specific mappings here because the /8 routes encompass all shoot networks
 	_, _, _, err = network.ShootNetworksForNetmap(r.shootPodNetworks, r.shootServiceNetworks, r.shootNodeNetworks)
 	if err != nil {
 		return err

--- a/cmd/vpn_client/app/pathcontroller/pathcontroller.go
+++ b/cmd/vpn_client/app/pathcontroller/pathcontroller.go
@@ -76,7 +76,7 @@ func run(ctx context.Context, _ context.CancelFunc, log logr.Logger) error {
 
 	// map pod IP to 241/8 range if needed
 	if net.ParseIP(podIP).To4() != nil && overlap {
-		mappedIP, err := network.Netmap(podIP, constants.SeedPodNetworkMapped)
+		mappedIP, err := network.NetmapIP(podIP, constants.SeedPodNetworkMapped)
 		if err != nil {
 			log.Info("error mapping pod IP to 241/8 range", "podIP", podIP, "error", err)
 			return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,6 +29,8 @@ const (
 	SeedPodNetworkMapped      = constants.ReservedSeedPodNetworkMappedRange
 
 	EnvoyVPNGroupId = 31415 //TODO: use constants.EnvoyVPNGroupId from Gardener
+	// NetmapCIDRMaskSizeLimit is the maximum prefix length for shoot network mapping. Shoot networks cannot be smaller than this value.
+	NetmapCIDRMaskSizeLimit = 28
 )
 
 // DefaultVPNNetwork is the default IPv6 transfer network used by VPN.

--- a/pkg/network/iptables.go
+++ b/pkg/network/iptables.go
@@ -37,22 +37,3 @@ func iptablesWorks(path string) bool {
 	// check both iptables and ip6tables
 	return exec.Command(path, "-L").Run() == nil && exec.Command(adjustPath(path, iptables.ProtocolIPv6), "-L").Run() == nil // #nosec: G204 -- Command line is completely static "/usr/sbin/(iptables|ip6tables)-(legacy|nft) -L".
 }
-
-// ShootNetworksForNetmap verifies that there is exactly one IPv4 pod, service, and node network in the provided lists.
-// This is needed until more than one network is supported in the netmap iptables rules and more can be defined in the shoot spec.
-// The function returns the IPv4 networks or an error if the requirements are not met.
-func ShootNetworksForNetmap(ShootPodNetworks, ShootServiceNetworks, ShootNodeNetworks []CIDR) (ipv4PodNetworks []CIDR, ipv4ServiceNetworks []CIDR, ipv4NodeNetworks []CIDR, err error) {
-	ipv4PodNetworks = GetByIPFamily(ShootPodNetworks, IPv4Family)
-	if len(ipv4PodNetworks) > 1 {
-		return nil, nil, nil, fmt.Errorf("exactly one IPv4 pod network is supported. IPv4 pod networks: %s", ipv4PodNetworks)
-	}
-	ipv4ServiceNetworks = GetByIPFamily(ShootServiceNetworks, IPv4Family)
-	if len(ipv4ServiceNetworks) > 1 {
-		return nil, nil, nil, fmt.Errorf("exactly one IPv4 service network is supported. IPv4 service networks: %s", ipv4ServiceNetworks)
-	}
-	ipv4NodeNetworks = GetByIPFamily(ShootNodeNetworks, IPv4Family)
-	if len(ipv4NodeNetworks) > 1 {
-		return nil, nil, nil, fmt.Errorf("exactly one IPv4 node network is supported. IPv4 node networks: %s", ipv4NodeNetworks)
-	}
-	return ipv4PodNetworks, ipv4ServiceNetworks, ipv4NodeNetworks, nil
-}

--- a/pkg/network/netmap.go
+++ b/pkg/network/netmap.go
@@ -7,10 +7,13 @@ package network
 import (
 	"fmt"
 	"net"
+	"sort"
+
+	"github.com/gardener/vpn2/pkg/constants"
 )
 
-// Netmap maps the given IP address to a new IP address in the provided subnet.
-func Netmap(ip string, subnet string) (string, error) {
+// NetmapIP maps the given IP address to a new IP address in the provided subnet.
+func NetmapIP(ip string, subnet string) (string, error) {
 	srcIp := net.ParseIP(ip)
 	if srcIp == nil {
 		return "", fmt.Errorf("failed to parse ip: %v", ip)
@@ -19,14 +22,14 @@ func Netmap(ip string, subnet string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse subnet: %v", err)
 	}
-	mappedIP, err := netmap(srcIp, *subnetMask)
+	mappedIP, err := netmapIP(srcIp, *subnetMask)
 	if err != nil {
 		return "", err
 	}
 	return mappedIP.String(), nil
 }
 
-func netmap(ip net.IP, subnet net.IPNet) (net.IP, error) {
+func netmapIP(ip net.IP, subnet net.IPNet) (net.IP, error) {
 	// Ensure the IP is in the correct format (IPv4 or IPv6)
 	ipv4 := ip.To4()
 	subnetBase := subnet.IP.To4()
@@ -41,4 +44,192 @@ func netmap(ip net.IP, subnet net.IPNet) (net.IP, error) {
 	}
 
 	return mappedIP, nil
+}
+
+// subnetSplit splits a parent *net.IPNet into all subnets of the given newPrefixLen length.
+func subnetSplit(parent *net.IPNet, newPrefixLen int) ([]*net.IPNet, error) {
+	parentPrefixLen, bits := parent.Mask.Size()
+	if newPrefixLen < parentPrefixLen || newPrefixLen > bits {
+		return nil, fmt.Errorf("invalid new prefix length %d for parent subnet %s", newPrefixLen, parent.String())
+	}
+	if newPrefixLen > constants.NetmapCIDRMaskSizeLimit {
+		return nil, fmt.Errorf("prefix length %d exceeds the maximum allowed length of %d", newPrefixLen, constants.NetmapCIDRMaskSizeLimit)
+	}
+	var (
+		subnets      []*net.IPNet
+		countSubnets uint32
+		numSubnets   uint32
+		baseInt      uint32
+		base         net.IP
+		incr         uint32
+	)
+
+	numSubnets = 1 << (newPrefixLen - parentPrefixLen)
+	base = parent.IP.Mask(parent.Mask).To4()
+	if base == nil {
+		return nil, fmt.Errorf("only IPv4 is supported")
+	}
+	baseInt = uint32(base[0])<<24 | uint32(base[1])<<16 | uint32(base[2])<<8 | uint32(base[3])
+	subnets = make([]*net.IPNet, numSubnets)
+	incr = 1 << (32 - newPrefixLen)
+
+	for countSubnets = 0; countSubnets < numSubnets; countSubnets++ {
+		ipInt := baseInt + countSubnets*incr
+		ip := net.IPv4(
+			byte(ipInt>>24),
+			byte(ipInt>>16),
+			byte(ipInt>>8),
+			byte(ipInt),
+		)
+		mask := net.CIDRMask(newPrefixLen, bits)
+		subnets[countSubnets] = &net.IPNet{IP: ip.Mask(mask), Mask: mask}
+	}
+	return subnets, nil
+}
+
+func netmapSubnet(srcNet net.IPNet, dstNet net.IPNet) (net.IPNet, error) {
+	// Ensure the source and destination networks are both IPv4
+	if srcNet.IP.To4() == nil || dstNet.IP.To4() == nil {
+		return net.IPNet{}, fmt.Errorf("only IPv4 is supported for subnet mapping")
+	}
+
+	// Map the source network IP to the destination network
+	mappedIP, err := netmapIP(srcNet.IP, dstNet)
+	if err != nil {
+		return net.IPNet{}, err
+	}
+
+	// Create a new IPNet with the mapped IP and the destination mask
+	return net.IPNet{
+		IP:   mappedIP,
+		Mask: dstNet.Mask,
+	}, nil
+}
+
+// NetmapSubnets maps multiple source subnets to a single destination subnet.
+// It returns a map where keys are source CIDRs and values are the mapped destination CIDRs.
+func NetmapSubnets(srcCIDRs []string, dstCIDR string) (map[string]string, error) {
+	dstIPNet, err := ParseIPNet(dstCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse destination CIDR: %w", err)
+	}
+
+	type srcInfo struct {
+		raw    string
+		ipnet  *net.IPNet
+		prefix int
+	}
+	var srcInfos []srcInfo
+	for _, src := range srcCIDRs {
+		ipnet, err := ParseIPNet(src)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse source subnet %s: %w", src, err)
+		}
+		ones, bits := ipnet.Mask.Size()
+		if bits != 32 {
+			return nil, fmt.Errorf("only IPv4 is supported: %s", src)
+		}
+		srcInfos = append(srcInfos, srcInfo{raw: src, ipnet: ipnet.ToIPNet(), prefix: ones})
+	}
+
+	// Sort by decreasing prefix length (largest subnets first)
+	sort.Slice(srcInfos, func(i, j int) bool {
+		return srcInfos[i].prefix < srcInfos[j].prefix
+	})
+
+	// Recursive mapping function
+	var mapSubnetsRec func(srcs []srcInfo, dstSubnets []*net.IPNet, result map[string]string) error
+	mapSubnetsRec = func(srcs []srcInfo, dstSubnets []*net.IPNet, result map[string]string) error {
+		if len(srcs) == 0 {
+			return nil // All mapped
+		}
+		// Take the largest src subnet
+		src := srcs[0]
+		// Split available dst subnets into chunks of src.prefix
+		var candidateSubnets []*net.IPNet
+		for _, dst := range dstSubnets {
+			subnets, err := subnetSplit(dst, src.prefix)
+			if err != nil {
+				return fmt.Errorf("failed to split destination subnet: %w", err)
+			}
+			candidateSubnets = append(candidateSubnets, subnets...)
+		}
+		if len(candidateSubnets) == 0 {
+			return fmt.Errorf("not enough space in %s to fit all source subnets: %s", dstCIDR, srcCIDRs)
+		}
+		// Map src to the first candidate
+		mapped, err := netmapSubnet(*src.ipnet, *candidateSubnets[0])
+		if err != nil {
+			return fmt.Errorf("failed to map subnet %s: %w", src.raw, err)
+		}
+		result[src.raw] = mapped.String()
+		// Remove the mapped subnets and recurse
+		return mapSubnetsRec(srcs[1:], candidateSubnets[1:], result)
+	}
+
+	// Start recursion with the whole dstCIDR
+	result := make(map[string]string)
+	err = mapSubnetsRec(srcInfos, []*net.IPNet{dstIPNet.ToIPNet()}, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// NetmapCIDRs maps a list of source CIDRs to a destination CIDR.
+// It returns a map where keys are pointers to source CIDRs and values are the mapped destination CIDRs.
+func NetmapCIDRs(srcCIDRs []CIDR, dstCIDR CIDR) (map[*CIDR]CIDR, error) {
+	// We convert CIDRs to strings for the NetmapSubnets function internally
+	srcCIDRsStr := make([]string, len(srcCIDRs))
+	for i, cidr := range srcCIDRs {
+		srcCIDRsStr[i] = cidr.String()
+	}
+	dstCIDRStr := dstCIDR.String()
+
+	mappedStr, err := NetmapSubnets(srcCIDRsStr, dstCIDRStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to map CIDRs: %w", err)
+	}
+	mappedCIDRs := make(map[*CIDR]CIDR, len(mappedStr))
+	for src, dst := range mappedStr {
+		srcCIDR, err := ParseIPNet(src)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse source CIDR %s: %w", src, err)
+		}
+		dstCIDR, err := ParseIPNet(dst)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse destination CIDR %s: %w", dst, err)
+		}
+		mappedCIDRs[&srcCIDR] = dstCIDR
+	}
+	return mappedCIDRs, nil
+}
+
+// ShootNetworksForNetmap returns the mappings of shoot pod, service, and node networks to subnets of their reserved mapping ranges.
+// This will work for an arbitrary number of networks as along as they fit into the reserved ranges.
+// Example: node networks of 10.100.80.0/16, 10.99.14.0/24, 10.99.15.0/24 will be mapped to
+// 242.0.0.0/16, 242.1.0.0/24, 242.1.1.0/24 all fitting into 242.0.0.0/8 and non-overlapping with each other.
+func ShootNetworksForNetmap(
+	ShootPodNetworks, ShootServiceNetworks, ShootNodeNetworks []CIDR,
+) (ipv4PodNetworkMappings, ipv4ServiceNetworkMappings, ipv4NodeNetworkMappings map[*CIDR]CIDR, err error) {
+	ipv4PodNetworks := GetByIPFamily(ShootPodNetworks, IPv4Family)
+	ipv4ServiceNetworks := GetByIPFamily(ShootServiceNetworks, IPv4Family)
+	ipv4NodeNetworks := GetByIPFamily(ShootNodeNetworks, IPv4Family)
+
+	ipv4PodNetworkMappings, err = NetmapCIDRs(ipv4PodNetworks, ParseIPNetIgnoreError(constants.ShootPodNetworkMapped))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to map shoot pod networks: %w", err)
+	}
+
+	ipv4ServiceNetworkMappings, err = NetmapCIDRs(ipv4ServiceNetworks, ParseIPNetIgnoreError(constants.ShootServiceNetworkMapped))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to map shoot service networks: %w", err)
+	}
+
+	ipv4NodeNetworkMappings, err = NetmapCIDRs(ipv4NodeNetworks, ParseIPNetIgnoreError(constants.ShootNodeNetworkMapped))
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to map shoot node networks: %w", err)
+	}
+
+	return ipv4PodNetworkMappings, ipv4ServiceNetworkMappings, ipv4NodeNetworkMappings, nil
 }

--- a/pkg/network/netmap_test.go
+++ b/pkg/network/netmap_test.go
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package network_test
+package network
 
 import (
+	"net"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/gardener/vpn2/pkg/network"
+	"k8s.io/utils/ptr"
 )
 
 func TestNetwork(t *testing.T) {
@@ -18,7 +18,7 @@ func TestNetwork(t *testing.T) {
 	RunSpecs(t, "Netmap Suite")
 }
 
-var _ = Describe("Netmap", func() {
+var _ = Describe("NetmapIP", func() {
 	type testCase struct {
 		description string
 		inputIP     string
@@ -28,9 +28,9 @@ var _ = Describe("Netmap", func() {
 		errorMsg    string
 	}
 
-	DescribeTable("Netmap function",
+	DescribeTable("NetmapIP function",
 		func(tc testCase) {
-			result, err := network.Netmap(tc.inputIP, tc.subnet)
+			result, err := NetmapIP(tc.inputIP, tc.subnet)
 			if tc.expectErr {
 				Expect(err).To(HaveOccurred())
 				if tc.errorMsg != "" {
@@ -88,4 +88,262 @@ var _ = Describe("Netmap", func() {
 			errorMsg:    "only IPv4 is supported",
 		}),
 	)
+
+})
+
+var _ = Describe("netmapIP", func() {
+	It("should map IPv4 correctly", func() {
+		ip := net.ParseIP("192.168.1.100")
+		_, subnet, _ := net.ParseCIDR("10.0.0.0/8")
+		mapped, err := netmapIP(ip, *subnet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped.String()).To(Equal("10.168.1.100"))
+	})
+	It("should fail for IPv6", func() {
+		ip := net.ParseIP("2001:db8::1")
+		_, subnet, _ := net.ParseCIDR("10.0.0.0/8")
+		_, err := netmapIP(ip, *subnet)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("subnetSplit", func() {
+	It("should split /8 into 256 /16s", func() {
+		_, parent, _ := net.ParseCIDR("242.0.0.0/8")
+		subnets, err := subnetSplit(parent, 16)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(subnets)).To(Equal(256))
+		Expect(subnets[0].String()).To(Equal("242.0.0.0/16"))
+		Expect(subnets[255].String()).To(Equal("242.255.0.0/16"))
+	})
+	It("should fail for invalid prefix", func() {
+		_, parent, _ := net.ParseCIDR("10.0.0.0/8")
+		_, err := subnetSplit(parent, 4)
+		Expect(err).To(HaveOccurred())
+	})
+	It("should fail for IPv6", func() {
+		_, parent, _ := net.ParseCIDR("2001:db8::/32")
+		_, err := subnetSplit(parent, 40)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("netmapSubnet", func() {
+	It("should map subnet correctly", func() {
+		_, src, _ := net.ParseCIDR("10.1.2.0/24")
+		_, dst, _ := net.ParseCIDR("242.1.2.0/24")
+		mapped, err := netmapSubnet(*src, *dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mapped.IP.String()).To(Equal("242.1.2.0"))
+		Expect(mapped.Mask.String()).To(Equal(dst.Mask.String()))
+	})
+	It("should fail for IPv6", func() {
+		_, src, _ := net.ParseCIDR("2001:db8::/32")
+		_, dst, _ := net.ParseCIDR("242.1.2.0/24")
+		_, err := netmapSubnet(*src, *dst)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("NetmapSubnets", func() {
+	It("should map multiple subnets non-overlapping", func() {
+		srcs := []string{"10.1.0.0/16", "10.2.0.0/16", "10.3.1.0/24", "10.4.2.240/28"}
+		dst := "242.0.0.0/8"
+		mapped, err := NetmapSubnets(srcs, dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(mapped)).To(Equal(4))
+		// Verify the correct mapping
+		expectedMapping := map[string]string{
+			"10.1.0.0/16":   "242.0.0.0/16",
+			"10.2.0.0/16":   "242.1.0.0/16",
+			"10.3.1.0/24":   "242.2.0.0/24",
+			"10.4.2.240/28": "242.2.1.0/28",
+		}
+		Expect(mapped).To(Equal(expectedMapping))
+		// Verify none of the mapped networks overlap
+		for _, dst := range mapped {
+			for _, otherDst := range mapped {
+				if dst != otherDst {
+					Expect(Overlap(ParseIPNetIgnoreError(dst), ParseIPNetIgnoreError(otherDst))).To(BeFalse(), "Mapped networks should not overlap")
+				}
+			}
+		}
+
+	})
+	It("should fail if not enough space", func() {
+		srcs := []string{"10.1.0.0/9", "10.2.0.0/9", "10.3.0.0/9"}
+		dst := "242.0.0.0/8"
+		_, err := NetmapSubnets(srcs, dst)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("NetmapCIDRs", func() {
+	It("should map CIDRs", func() {
+		srcs := []CIDR{
+			ParseIPNetIgnoreError("10.1.0.0/16"),
+			ParseIPNetIgnoreError("10.2.0.0/24"),
+		}
+		dst := ParseIPNetIgnoreError("242.0.0.0/8")
+		mapped, err := NetmapCIDRs(srcs, dst)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(mapped)).To(Equal(2))
+
+		// Convert to strings for easier equality check
+		mappedStr := make(map[string]string, len(mapped))
+		for src, dst := range mapped {
+			mappedStr[src.String()] = dst.String()
+		}
+
+		// Verify the correct mapping
+		expectedMapping := map[string]string{
+			"10.1.0.0/16": "242.0.0.0/16",
+			"10.2.0.0/24": "242.1.0.0/24",
+		}
+
+		Expect(mappedStr).To(Equal(expectedMapping))
+	})
+	It("should fail if not enough space", func() {
+		srcs := []CIDR{
+			ParseIPNetIgnoreError("10.1.0.0/8"),
+			ParseIPNetIgnoreError("10.2.0.0/8"),
+		}
+		dst := ParseIPNetIgnoreError("242.0.0.0/8")
+		_, err := NetmapCIDRs(srcs, dst)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not enough space in 242.0.0.0/8 to fit all source subnets"))
+	})
+})
+
+var _ = Describe("ShootNetworksForNetmap", func() {
+	It("should map pod, service, and node networks", func() {
+		pods := []CIDR{ParseIPNetIgnoreError("10.1.0.0/16")}
+		services := []CIDR{ParseIPNetIgnoreError("10.2.0.0/16")}
+		nodes := []CIDR{ParseIPNetIgnoreError("10.3.0.0/24")}
+		podMap, svcMap, nodeMap, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(podMap)).To(Equal(1))
+		Expect(len(svcMap)).To(Equal(1))
+		Expect(len(nodeMap)).To(Equal(1))
+	})
+	It("should fail if mapping fails", func() {
+		pods := []CIDR{ParseIPNetIgnoreError("10.1.0.0/8"), ParseIPNetIgnoreError("10.2.0.0/8")}
+		services := []CIDR{}
+		nodes := []CIDR{}
+		_, _, _, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).To(HaveOccurred())
+	})
+	It("should map multiple and dual-stack pod, service, and node networks", func() {
+		pods := []CIDR{
+			ParseIPNetIgnoreError("10.1.0.0/16"),
+			ParseIPNetIgnoreError("10.2.0.0/24"),
+			ParseIPNetIgnoreError("fd00:1::/64"),
+		}
+		services := []CIDR{
+			ParseIPNetIgnoreError("10.3.0.0/16"),
+			ParseIPNetIgnoreError("fd00:2::/112"),
+		}
+		nodes := []CIDR{
+			ParseIPNetIgnoreError("10.219.45.0/26"),
+			ParseIPNetIgnoreError("10.219.45.64/26"),
+			ParseIPNetIgnoreError("10.96.0.0/11"),
+			ParseIPNetIgnoreError("10.128.0.0/12"),
+			ParseIPNetIgnoreError("fd00:3::/120"),
+		}
+		podMap, svcMap, nodeMap, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).NotTo(HaveOccurred())
+		// Only IPv4 mappings are expected
+		Expect(len(podMap)).To(Equal(2))
+		Expect(len(svcMap)).To(Equal(1))
+		Expect(len(nodeMap)).To(Equal(4))
+		// Verify the correct mapping
+		Expect(podMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.1.0.0/16")),
+			ParseIPNetIgnoreError("244.0.0.0/16"),
+		))
+		Expect(podMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.2.0.0/24")),
+			ParseIPNetIgnoreError("244.1.0.0/24"),
+		))
+		Expect(svcMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.3.0.0/16")),
+			ParseIPNetIgnoreError("243.0.0.0/16"),
+		))
+		Expect(nodeMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.96.0.0/11")),
+			ParseIPNetIgnoreError("242.0.0.0/11"),
+		))
+		Expect(nodeMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.128.0.0/12")),
+			ParseIPNetIgnoreError("242.32.0.0/12"),
+		))
+		Expect(nodeMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.219.45.0/26")),
+			ParseIPNetIgnoreError("242.48.0.0/26"),
+		))
+		Expect(nodeMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.219.45.64/26")),
+			ParseIPNetIgnoreError("242.48.0.64/26"),
+		))
+		// Verify none of the mapped networks overlap
+		for _, m := range []map[*CIDR]CIDR{podMap, svcMap, nodeMap} {
+			for _, dst := range m {
+				for _, otherDst := range m {
+					if !dst.Equal(otherDst) {
+						Expect(Overlap(dst, otherDst)).To(BeFalse(), "Mapped networks should not overlap")
+					}
+				}
+			}
+		}
+	})
+	It("should handle only IPv6 networks gracefully (no IPv4 mappings)", func() {
+		pods := []CIDR{ParseIPNetIgnoreError("fd00:1::/64")}
+		services := []CIDR{ParseIPNetIgnoreError("fd00:2::/112")}
+		nodes := []CIDR{ParseIPNetIgnoreError("fd00:3::/120")}
+		podMap, svcMap, nodeMap, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(podMap)).To(Equal(0))
+		Expect(len(svcMap)).To(Equal(0))
+		Expect(len(nodeMap)).To(Equal(0))
+	})
+	It("should map dual-stack networks and ignore IPv6", func() {
+		pods := []CIDR{
+			ParseIPNetIgnoreError("10.10.0.0/16"),
+			ParseIPNetIgnoreError("fd00:10::/64"),
+		}
+		services := []CIDR{
+			ParseIPNetIgnoreError("10.20.0.0/16"),
+			ParseIPNetIgnoreError("fd00:20::/112"),
+		}
+		nodes := []CIDR{
+			ParseIPNetIgnoreError("10.30.0.0/24"),
+			ParseIPNetIgnoreError("fd00:30::/120"),
+		}
+		podMap, svcMap, nodeMap, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(podMap)).To(Equal(1))
+		Expect(len(svcMap)).To(Equal(1))
+		Expect(len(nodeMap)).To(Equal(1))
+		// Verify the correct mapping
+		Expect(podMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.10.0.0/16")),
+			ParseIPNetIgnoreError("244.0.0.0/16"),
+		))
+		Expect(svcMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.20.0.0/16")),
+			ParseIPNetIgnoreError("243.0.0.0/16"),
+		))
+		Expect(nodeMap).To(HaveKeyWithValue(
+			ptr.To(ParseIPNetIgnoreError("10.30.0.0/24")),
+			ParseIPNetIgnoreError("242.0.0.0/24"),
+		))
+	})
+	It("should fail if shoot networks are too small", func() {
+		pods := []CIDR{ParseIPNetIgnoreError("10.1.0.0/16")}
+		services := []CIDR{ParseIPNetIgnoreError("10.2.0.0/16")}
+		nodes := []CIDR{ParseIPNetIgnoreError("10.3.0.0/24"), ParseIPNetIgnoreError("100.1.12.0/29")}
+		_, _, _, err := ShootNetworksForNetmap(pods, services, nodes)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("prefix length 29 exceeds the maximum allowed length of 28"))
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

- We currently support only one network range per shoot network wrt double-NAT mapping in the VPN tunnel.
- This is somewhat limiting and wasteful as e.g. the [ironcore metal extension](https://github.com/ironcore-dev/gardener-extension-provider-ironcore-metal/blob/main/pkg/controller/infrastructure/actuator_reconcile.go#L30-L40) has the ability to add additional node networks to the infrastructure status which will reconcile into the shoot cluster VPN.
- This PR adds more flexibility in the 240/4 subnet mapping in the following way:

1. Shoot networks can now have more than one value
2. When mapping to their 240/4 NAT range, the algorithm sorts the shoot networks by their prefix length
3. The NAT range is split into subnets of the largest prefix
4. The first network range gets mapped to the next available subnet in the NAT range
5. The mapped NAT range is removed from the list and the recursion starts over at step 3 with the remaining network ranges and NAT ranges until all have been mapped
6. If there aren't any NAT ranges left or the total of all network ranges exceed the total NAT range, an error is returned


Example: Mapping pods to 244/8
|Shoot Pod Ranges|Mapped Ranges|
|-------------------|----------------|
|100.80.0.0/16| 244.0.0.0/16|, 
|100.81.10.0/24| 244.1.0.0/24|, 
|100.81.11.0/24| 244.1.1.0/24|, 

Example: Mapping nodes to 242/8
|Shoot Node Ranges|Mapped Ranges|
|-------------------|----------------|
|100.0.0.0/9 | 242.0.0.0/9|, 
|101.0.0.0/9| 242.128.0.0/9|, 
|102.0.0.0/9| ERROR - can't map to /8|, 


**Special notes for your reviewer**:
- Currently only applies to shoot networks. Multiple seed pod networks not yet supported (requires g/g change). So the seed network mapping remains 1:1 to the 241/8 range for now. 
- Added a limitation to /28 as the smallest possible network range for performance reasons. If there is need for single-ip mappings we can add special handling for them later if needed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
8. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
VPN now supports multiple shoot pod/service/node ranges provided that each range's combined number of hosts does not exceed a /8 network size.
```
