### PR TITLE
fix: clean up attached ips from tun/tap devices at startup

### DIFF
--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -99,5 +99,9 @@ func run(_ context.Context, log logr.Logger) error {
 
 	values := vpnConfig(log, cfg)
 
+	if err := vpn_client.Cleanup(log, values); err != nil {
+		return err
+	}
+
 	return openvpn.WriteClientConfigFile(values)
 }

--- a/pkg/vpn_client/cleanup.go
+++ b/pkg/vpn_client/cleanup.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package vpn_client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/gardener/vpn2/pkg/openvpn"
+)
+
+func Cleanup(log logr.Logger, values openvpn.ClientValues) error {
+	log.Info("Cleaning up VPN client resources")
+
+	// Remove any IPv6 address assigned to the VPN device. It will be reassigned by openvpn on the next connection.
+	tuntap, err := netlink.LinkByName(values.Device)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			log.Info("VPN device not found, nothing to clean up", "device", values.Device)
+			return nil
+		}
+		return fmt.Errorf("failed to get link %s: %w", values.Device, err)
+	}
+
+	if err := netlink.LinkSetDown(tuntap); err != nil {
+		return fmt.Errorf("failed to set link %s down: %w", values.Device, err)
+	}
+
+	addr, err := netlink.AddrList(tuntap, unix.AF_INET6)
+	if err != nil {
+		return fmt.Errorf("failed to list addresses for link %s: %w", values.Device, err)
+	}
+	for _, a := range addr {
+		if err := netlink.AddrDel(tuntap, &a); err != nil {
+			return fmt.Errorf("failed to delete address %s from link %s: %w", a.String(), values.Device, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- When the openvpn client crashes it tries to restart
- If the tun/tap device is already set up from the previous run, the restart will fail because openvpn tries to attach the IP address pushed by the server to its tunnel device and the tunnel device already has that ip from last time
- This PR adds a cleanup function that checks for pre-existing (v6) IPs on the tunnel device and removes them before openvpn is started
- This allows openvpn to safely restart after a crash

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
openvpn client will now restart successfully after a crash
```
