### PR TITLE
Mtu fix both directions via TCPMSS rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN    cp -d /lib/ld-musl-* ./lib                                           && e
     && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo package iptables
 
 RUN if [ "$DEBUG" = "true" ]; then \
-       apk add --update net-tools tcpdump ndisc6 && \
+       apk add --update net-tools tcpdump ndisc6 iputils-tracepath && \
        cp -d /bin/* ./bin && \
        cp -d /usr/bin/* ./usr/bin && \
        cp -d /usr/lib/libpcap* ./usr/lib && \

--- a/pkg/vpn_client/iptables.go
+++ b/pkg/vpn_client/iptables.go
@@ -83,7 +83,7 @@ func SetIPTableRules(log logr.Logger, cfg config.VPNClient) error {
 				}
 			}
 
-			err = ipTable.AppendUnique("filter", "FORWARD", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", "1380")
+			err = ipTable.AppendUnique("mangle", "POSTROUTING", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", "1380")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

The current MSS fix only applies for SYN packets coming back from shoot pods or nodes, not to SYNs going from the seed to the shoot. 

This has the side-effect that tcp servers on the shoot side (e.g. kubelet) assume a higher MSS (usually 1412 or 1400) than possible. MSS is technically feasible with overlay as the MTU is 1440 on the tunl0 devices. However, any options on the tcp header, e.g. timestamps will add more bytes to the overall packet length and overshoot the 1440 MTU limit, causing ICMP packets. for PMTU discovery and connection discruptions if those ICMP packets are lost along the way.

The PR moves the `TCPMSS` iptables rule from the `FORWARD` chain in the `filter` table to the `POSTROUTING` chain in the `mangle` table. This makes sure that the rule fires in both directions of traffic.


**Special notes for your reviewer**:
- Don't merge yet, there are some answers to be given:
  - Would the old `--clamp-to-pmtu` setting also work? This would improve performance on clusters with larger node MTU or without overlay.
  - How does the fix help with external load balancers talking into the shoot? There have been reports of connectivity issues with pods exposed via service type load balancer that happened to be running on vpn-shoot nodes (and also using overlay).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator

```
