### PR TITLE
Remove manual ndp

### DIFF
--- a/cmd/vpn_client/app/pathcontroller/ping.go
+++ b/cmd/vpn_client/app/pathcontroller/ping.go
@@ -10,16 +10,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv6"
-
-	"github.com/gardener/vpn2/pkg/constants"
-	"github.com/gardener/vpn2/pkg/network"
 )
 
 type icmpPinger struct {
@@ -40,19 +36,6 @@ func (p *icmpPinger) Ping(client net.IP) error {
 			break
 		}
 		p.log.Info("ping failed", "ip", client, "error", err, "try", fmt.Sprintf("%d/%d", try, tries))
-
-		if try == 1 {
-			go func() {
-				// send neighbor solicitation to speed up discovery the link-layer address of a neighbor
-				p.log.Info("sending neighbor solicitation", "ip", client.String())
-				err := p.neighborSolicitation(client)
-				if err != nil {
-					p.log.Info("neighbor solicitation failed", "error", err.Error())
-				} else {
-					p.log.Info("received neighbor advertisement")
-				}
-			}()
-		}
 	}
 	return err
 }
@@ -86,12 +69,12 @@ func (p *icmpPinger) ping(client net.IP) error {
 		return fmt.Errorf("error setting deadline: %w", err)
 	}
 
-	seq := p.lastSeq.Add(1) & 0xffff // is marshalled as uint16 so we need to mask it
+	seq := p.lastSeq.Add(1) & 0xffff // is marshaled as uint16 so we need to mask it
 	msg := icmp.Message{
 		Type: ipv6.ICMPTypeEchoRequest,
 		Code: 0,
 		Body: &icmp.Echo{
-			ID:   os.Getpid() & 0xffff, // is marshalled as uint16 so we need to mask it
+			ID:   os.Getpid() & 0xffff, // is marshaled as uint16 so we need to mask it
 			Seq:  int(seq),
 			Data: []byte(echoPayload),
 		},
@@ -131,131 +114,4 @@ func (p *icmpPinger) ping(client net.IP) error {
 	default:
 		return err
 	}
-}
-
-func (p *icmpPinger) neighborSolicitation(client net.IP) error {
-	if len(client) != net.IPv6len {
-		return fmt.Errorf("only usable with ipv6")
-	}
-	device, err := net.InterfaceByName(constants.BondDevice)
-	if err != nil {
-		return fmt.Errorf("bonding device %q not found: %w", constants.BondDevice, err)
-	}
-	ips, err := network.GetLinkIPAddressesByName(constants.BondDevice, network.ScopeLink)
-	if err != nil {
-		return fmt.Errorf("getting link IP addresses failed: %w", err)
-	}
-	if len(ips) == 0 {
-		return fmt.Errorf("no link IP address for device %s", constants.BondDevice)
-	} else if len(ips) > 1 {
-		return fmt.Errorf("link IP address not unique for device %s: [%s]", constants.BondDevice, strings.Join(toStringArray(ips), ","))
-	}
-
-	ns := icmp.Message{
-		Type: ipv6.ICMPTypeNeighborSolicitation,
-		Code: 0,
-		Body: &icmp.RawBody{
-			Data: buildNSBody(client, device.HardwareAddr),
-		},
-	}
-
-	data, err := ns.Marshal(nil)
-	if err != nil {
-		return fmt.Errorf("error marshalling ICMP message: %w", err)
-	}
-
-	conn, err := icmp.ListenPacket("ip6:ipv6-icmp", fmt.Sprintf("%s%%%s", ips[0], constants.BondDevice))
-	if err != nil {
-		return fmt.Errorf("error opening raw socket: %w", err)
-	}
-	defer conn.Close()
-
-	deadline := time.Now().Add(p.timeout / 2)
-	pc := conn.IPv6PacketConn()
-	if err := pc.SetReadDeadline(deadline); err != nil {
-		return fmt.Errorf("error setting deadline: %w", err)
-	}
-
-	// The multicast hop limit of 255 ensures that the Neighbor Solicitation message
-	// remains within the local link. If the hop limit is set to any value less than 255,
-	// the message might have been relayed or forwarded by a router, which is not desirable.
-	// A hop limit of 255 guarantees that the packet is dropped if it has been routed.
-	// The packet is dropped silently if not set.
-	// see https://datatracker.ietf.org/doc/html/rfc4861#section-7.1.1
-	if err := pc.SetMulticastHopLimit(255); err != nil {
-		return fmt.Errorf("error setting multicast hop limit: %w", err)
-	}
-
-	// calculate solicited-node multicast address
-	destIP := net.ParseIP("ff02::1:ff00:0")
-	copy(destIP[13:], client[13:]) // copy last 24 bits
-	dst := &net.IPAddr{IP: destIP}
-	_, err = pc.WriteTo(data, nil, dst)
-	if err != nil {
-		return fmt.Errorf("error sending ICMP message to %s: %w", dst, err)
-	}
-
-	// Listen for Neighbor Advertisement response
-	reply := make([]byte, 1500)
-	n, _, _, err := pc.ReadFrom(reply)
-	if err != nil {
-		if neterr, ok := errors.AsType[net.Error](err); ok && neterr.Timeout() {
-			return fmt.Errorf("i/o timeout")
-		}
-		return fmt.Errorf("error reading from socket: %w", err)
-	}
-
-	rm, err := icmp.ParseMessage(ipv6.ICMPTypeNeighborAdvertisement.Protocol(), reply[:n])
-	if err != nil {
-		return fmt.Errorf("error parsing ICMP message: %w", err)
-	}
-
-	switch rm.Type {
-	case ipv6.ICMPTypeNeighborAdvertisement:
-		return nil
-	default:
-		return fmt.Errorf("received unexpected ICMP message: %#v", rm)
-	}
-}
-
-func buildNSBody(target net.IP, hwAddr net.HardwareAddr) []byte {
-	// ICMPv6 Neighbor Solicitation message body format:
-	// :    Octet 0    :    Octet 1    :    Octet 2    :    Octet 3    :
-	// :0              :    1          :        2      :            3  :
-	// :0 1 2 3 4 5 6 7:8 9 0 1 2 3 4 5:6 7 8 9 0 1 2 3:4 5 6 7 8 9 0 1:
-	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	// |                           Reserved (4 bytes)                  |
-	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	// |                                                               |
-	// +                                                               +
-	// |                                                               |
-	// +                       Target Address                          +
-	// |                                                               |
-	// +                                                               +
-	// |                                                               |
-	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	// |   Type (1)    |    Length     |             Data...
-	// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
-
-	buf := make([]byte, 22+len(hwAddr))
-	// Target Address (16 bytes)
-	copy(buf[4:20], target)
-
-	// Option: Source Link-Layer Address
-	buf[20] = 1 // Type (Source Link-Layer Address)
-	buf[21] = 1 // Length (in units of 8 octets)
-	copy(buf[22:], hwAddr)
-
-	return buf
-}
-
-func toStringArray(ips []net.IP) []string {
-	if len(ips) == 0 {
-		return nil
-	}
-	out := make([]string, len(ips))
-	for i, ip := range ips {
-		out[i] = ip.String()
-	}
-	return out
 }

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -1,3 +1,5 @@
+verb 3
+
 # don't cache authorization information in memory
 auth-nocache
 

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -1,3 +1,4 @@
+verb 3
 mode server
 tls-server
 topology subnet
@@ -12,7 +13,9 @@ data-ciphers AES-256-GCM:AES-256-CBC
 # manifest
 port 1194
 
-keepalive 10 60
+# send ping every 10 seconds, assume peer is down after 30 seconds without traffic
+# this value is pushed to the client, timeout is doubled on the server side, so the client is considered down after 60 seconds without traffic
+keepalive 10 30
 
 # client-config-dir to push client specific configuration
 client-config-dir /client-config-dir


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- This is a follow-up of an upstream issue where we observed confusing error messages like this one
```
{"log":"2026-03-20T00:13:58.042Z\tINFO\tping\tneighbor solicitation failed\t{\"error\": \"received unexpected ICMP message: \u0026icmp.Message{Type:135, Code:0, Checksum:5906, Body:(*icmp.RawBody)(0x22a0227a1f8)}\"}","logtag":"F"}
```

- The code did not handle NDP correctly as it expected only NA packets in response to its own NS packets but did not anticipate NS packets (type 135) from the other side as well.
- During testing, it was discovered that the neighbor cache is populated immediately while the pings are running, so the additional NS packets generated by VPN don't make sense. This is handled transparently by the operating system and can be verified using 
```
ip -6 neigh flush dev bond0 && tcpdump -i bond0 -n -l -f icmp6 | grep neighbor
```
on a HA VPN client in kube-apiserver.

Here is the result:
```
# ip -6 neigh flush dev bond0 && tcpdump -i bond0 -n -l -f icmp6 | grep neighbor

listening on bond0, link-type EN10MB (Ethernet), snapshot length 262144 bytes

13:24:02.519016 IP6 fe80::f824:8bff:fe14:179a > fd8f:6d53:b97a:1::a:8c4d: ICMP6, neighbor solicitation, who has fd8f:6d53:b97a:1::a:8c4d, length 32
13:24:02.519041 IP6 fd8f:6d53:b97a:1::a:8c4d > fe80::f824:8bff:fe14:179a: ICMP6, neighbor advertisement, tgt is fd8f:6d53:b97a:1::a:8c4d, length 24

(above are link-local advertisements, unused by vpn)

(below are the interesting ones: vpn-shoot-1 (b97a:1::b:1) and vpn-shoot-0 (b97a:1::b:0) ips NS packets are generated immediately and NA packets arrive as expected)

13:24:02.579671 IP6 fd8f:6d53:b97a:1::a:8c4d > ff02::1:ff0b:1: ICMP6, neighbor solicitation, who has fd8f:6d53:b97a:1::b:1, length 32
13:24:02.581268 IP6 fd8f:6d53:b97a:1::b:1 > fd8f:6d53:b97a:1::a:8c4d: ICMP6, neighbor advertisement, tgt is fd8f:6d53:b97a:1::b:1, length 32
13:24:03.514784 IP6 fd8f:6d53:b97a:1::a:8c4d > ff02::1:ff0b:0: ICMP6, neighbor solicitation, who has fd8f:6d53:b97a:1::b:0, length 32
13:24:03.516470 IP6 fd8f:6d53:b97a:1::b:0 > fd8f:6d53:b97a:1::a:8c4d: ICMP6, neighbor advertisement, tgt is fd8f:6d53:b97a:1::b:0, length 32
```

- So the manual NS/NA handling that causes the confusing error messages is not needed and can be removed
- As a separate improvement, I am raising the log level to get more details during the VPN handshake which adds more detail. For example, it turns this log message
```
2026-03-25 12:30:35 HTTP proxy returned bad status
```
into this log message
```
2026-03-25 12:30:35 HTTP proxy returned: 'HTTP/1.0 503 Service Unavailable'
```

- Another small fix is the keepalive change on the server side from `keepalive 10 60` to `keepalive 10 30`. The reason is that this keepalive value is actually pushed to the client and then [doubled and used by the server](https://openvpn.net/community-docs/community-articles/openvpn-2-6-manual.html#link-options-177179). So, if we want a 60s timeout on the server, we need to set this value to 30.
- The general idea is for clients to reconnect fast after 30s of no traffic but for the server to not disconnect clients too early. On the server, the `restart` part only drops the client connection, not actually restart the server. We don't want clients to sit on broken connections for 60s and rather do a fast reconnect.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Removed confusing neighbor solicitation log messages. Reduced client timeout for fast reconnects.
```
