### PR TITLE
Add OPENVPN_AUTO_MTU to derive tunnel MTU from network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,22 @@ Check if your kernel supports bond devices. You can check on nodes running docke
 `CONFIGURE_BONDING` must be set to either "m" or "y".
 
 For more information, see <https://www.kernelconfig.io/config_bonding?q=&kernelversion=6.1.90&arch=x86>
+
+## MTU tuning
+
+By default the OpenVPN tunnel uses the OpenVPN default MTU (1500 bytes). In environments where the underlying
+network supports a larger MTU (e.g. clusters connected via a high-speed backbone with jumbo frames), configuring
+a larger tunnel MTU can significantly improve throughput and reduce latency — in particular for geographically
+distant seed/shoot pairs.
+
+Set `OPENVPN_AUTO_MTU=true` on both **vpn-seed-server** and **vpn-client** to enable automatic MTU detection:
+
+```
+OPENVPN_AUTO_MTU=true
+```
+
+At startup each component scans its network interfaces, takes the MTU of the highest-MTU UP non-loopback
+interface (typically `eth0`), and derives the tunnel MTU by subtracting a fixed overhead of 130 bytes
+(IPv6 header 40 B + TCP header 40 B + OpenVPN AES-256-GCM/tls framing ≈ 50 B). With a typical container
+network MTU of `8930` this yields a tunnel MTU of `8800`. Leave the variable unset (default `false`) to keep
+the OpenVPN default and avoid any change in behaviour for standard environments.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For more information, see <https://www.kernelconfig.io/config_bonding?q=&kernelv
 
 ## MTU tuning
 
-By default the OpenVPN tunnel uses the OpenVPN default MTU (1500 bytes). In environments where the underlying
+By default, the OpenVPN tunnel uses the OpenVPN default MTU (1500 bytes). In environments where the underlying
 network supports a larger MTU (e.g. clusters connected via a high-speed backbone with jumbo frames), configuring
 a larger tunnel MTU can significantly improve throughput and reduce latency — in particular for geographically
 distant seed/shoot pairs.
@@ -169,8 +169,8 @@ Set `OPENVPN_AUTO_MTU=true` on both **vpn-seed-server** and **vpn-client** to en
 OPENVPN_AUTO_MTU=true
 ```
 
-At startup each component scans its network interfaces, takes the MTU of the highest-MTU UP non-loopback
-interface (typically `eth0`), and derives the tunnel MTU by subtracting a fixed overhead of 130 bytes
+At startup each component scans its network interfaces, takes the MTU of the default route interface (typically `eth0`),
+and derives the tunnel MTU by subtracting a fixed overhead of 130 bytes
 (IPv6 header 40 B + TCP header 40 B + OpenVPN AES-256-GCM/tls framing ≈ 50 B). With a typical container
 network MTU of `8930` this yields a tunnel MTU of `8800`. Leave the variable unset (default `false`) to keep
 the OpenVPN default and avoid any change in behaviour for standard environments.

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gardener/vpn2/cmd/vpn_client/app/setup"
 	"github.com/gardener/vpn2/pkg/config"
 	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
 	"github.com/gardener/vpn2/pkg/openvpn"
 	"github.com/gardener/vpn2/pkg/pprof"
 	"github.com/gardener/vpn2/pkg/utils"
@@ -54,7 +55,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
-func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
+func vpnConfig(log logr.Logger, cfg config.VPNClient, tunMTU int) openvpn.ClientValues {
 	v := openvpn.ClientValues{
 		Device:               constants.TunnelDevice,
 		IPFamily:             cfg.PrimaryIPFamily(),
@@ -66,6 +67,7 @@ func vpnConfig(log logr.Logger, cfg config.VPNClient) openvpn.ClientValues {
 		IsShootClient:        cfg.IsShootClient,
 		IsHA:                 cfg.IsHA,
 		SeedPodNetwork:       cfg.SeedPodNetwork.String(),
+		TunMTU:               tunMTU,
 	}
 	vpnSeedServer := "vpn-seed-server"
 
@@ -93,12 +95,20 @@ func run(_ context.Context, log logr.Logger) error {
 	}
 	log.Info("config parsed", "config", cfg)
 
+	tunMTU := 0
+	if cfg.AutoMTU {
+		tunMTU, err = network.DetectTunnelMTU(constants.TunnelMTUOverhead)
+		if err != nil {
+			return fmt.Errorf("failed to detect tunnel MTU: %w", err)
+		}
+	}
+
 	err = vpn_client.SetIPTableRules(log, cfg)
 	if err != nil {
 		return err
 	}
 
-	values := vpnConfig(log, cfg)
+	values := vpnConfig(log, cfg, tunMTU)
 
 	if err := vpn_client.Cleanup(log, values); err != nil {
 		return err

--- a/cmd/vpn_client/app/app.go
+++ b/cmd/vpn_client/app/app.go
@@ -101,6 +101,7 @@ func run(_ context.Context, log logr.Logger) error {
 		if err != nil {
 			return fmt.Errorf("failed to detect tunnel MTU: %w", err)
 		}
+		log.Info("detected tunnel MTU", "MTU", tunMTU)
 	}
 
 	err = vpn_client.SetIPTableRules(log, cfg)

--- a/cmd/vpn_client/app/pathcontroller/pathcontroller.go
+++ b/cmd/vpn_client/app/pathcontroller/pathcontroller.go
@@ -88,7 +88,7 @@ func run(ctx context.Context, _ context.CancelFunc, log logr.Logger) error {
 		pinger: &icmpPinger{
 			log:     log.WithName("ping"),
 			timeout: 1 * time.Second,
-			retries: 4,
+			retries: 9,
 		},
 		ticker:             time.NewTicker(constants.PathControllerUpdateInterval),
 		kubeAPIServerPodIP: podIP,

--- a/cmd/vpn_server/app/app.go
+++ b/cmd/vpn_server/app/app.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/gardener/vpn2/cmd/vpn_server/app/setup"
 	"github.com/gardener/vpn2/pkg/config"
+	"github.com/gardener/vpn2/pkg/constants"
+	"github.com/gardener/vpn2/pkg/network"
 	"github.com/gardener/vpn2/pkg/openvpn"
 	"github.com/gardener/vpn2/pkg/pprof"
 	"github.com/gardener/vpn2/pkg/utils"
@@ -74,6 +76,16 @@ func run(_ context.Context, log logr.Logger) error {
 	if err != nil {
 		return err
 	}
+
+	tunMTU := 0
+	if cfg.AutoMTU {
+		tunMTU, err = network.DetectTunnelMTU(constants.TunnelMTUOverhead)
+		if err != nil {
+			return fmt.Errorf("failed to detect tunnel MTU: %w", err)
+		}
+		log.Info("detected tunnel MTU", "MTU", tunMTU)
+	}
+	v.TunMTU = tunMTU
 
 	log.Info("writing openvpn config file", "values", v)
 	return openvpn.WriteServerConfigFiles(v)

--- a/pkg/config/vpn-client.go
+++ b/pkg/config/vpn-client.go
@@ -39,6 +39,7 @@ type VPNClient struct {
 	PodLabelSelector     string        `env:"POD_LABEL_SELECTOR" envDefault:"app=kubernetes,role=apiserver"`
 	WaitTime             time.Duration `env:"WAIT_TIME" envDefault:"2s"`
 	BondingMode          string        `env:"BONDING_MODE" envDefault:"active-backup"`
+	AutoMTU              bool          `env:"OPENVPN_AUTO_MTU"`
 }
 
 func (v VPNClient) PrimaryIPFamily() string {

--- a/pkg/config/vpn-server.go
+++ b/pkg/config/vpn-server.go
@@ -24,6 +24,7 @@ type VPNServer struct {
 	IsHA                 bool           `env:"IS_HA"`
 	HAVPNClients         int            `env:"HA_VPN_CLIENTS"`
 	LocalNodeIP          string         `env:"LOCAL_NODE_IP" envDefault:"255.255.255.255"`
+	AutoMTU              bool           `env:"OPENVPN_AUTO_MTU"`
 }
 
 func GetVPNServerConfig(log logr.Logger) (VPNServer, error) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,7 +18,8 @@ const (
 	// TunnelMTUOverhead is the number of bytes subtracted from the underlying interface MTU
 	// to derive the OpenVPN tun-mtu value (IPv6 header + TCP header + OpenVPN framing).
 	TunnelMTUOverhead = 130
-
+	// MinimumMTU is the smallest possible MTU that can still transport IPv6 packets
+	MinimumMTU = 1280
 	// BondDevice is the name of the bond device used for the HA deployment.
 	BondDevice = "bond0"
 	// TapDevice is the name of the tap device used for the HA VPN.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,6 +15,10 @@ const (
 	IPv4Family = "IPv4"
 	IPv6Family = "IPv6"
 
+	// TunnelMTUOverhead is the number of bytes subtracted from the underlying interface MTU
+	// to derive the OpenVPN tun-mtu value (IPv6 header + TCP header + OpenVPN framing).
+	TunnelMTUOverhead = 130
+
 	// BondDevice is the name of the bond device used for the HA deployment.
 	BondDevice = "bond0"
 	// TapDevice is the name of the tap device used for the HA VPN.

--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -22,30 +22,6 @@ const (
 	ScopeLink     = 253
 )
 
-// DetectTunnelMTU returns the MTU for the VPN tunnel device by finding the
-// highest-MTU UP non-loopback link (i.e. eth0 in a container) and subtracting
-// the given overhead for VPN encapsulation.
-func DetectTunnelMTU(overhead int) (int, error) {
-	links, err := netlink.LinkList()
-	if err != nil {
-		return 0, fmt.Errorf("failed to list links: %w", err)
-	}
-	best := 0
-	for _, l := range links {
-		attrs := l.Attrs()
-		if attrs.Flags&net.FlagLoopback != 0 || attrs.Flags&net.FlagUp == 0 {
-			continue
-		}
-		if attrs.MTU > best {
-			best = attrs.MTU
-		}
-	}
-	if best == 0 {
-		return 0, fmt.Errorf("no usable network interface found")
-	}
-	return best - overhead, nil
-}
-
 // DeleteLinkByName delete a link by name.
 func DeleteLinkByName(name string) error {
 	link, err := netlink.LinkByName(name)
@@ -79,12 +55,6 @@ func CreateTunnel(linkName string, local, remote net.IP) error {
 		// Tunnel Encapsulation Limit destination option on inner packets and drops them if
 		// the limit is exceeded (default 4). In VPN scenarios with multiple encapsulation
 		// layers this can cause silent packet drops.
-		//
-		// For context, a kernel regression in net/ipv6/ip6_tunnel.c (kernels 6.12.67–6.12.72)
-		// caused 100% RX drops on ip6tnl tunnels due to an inverted return-value check in
-		// __ip6_tnl_rcv() — see Debian bugs #1127597, #1127670. That bug was in a different
-		// code path and is fixed in 6.12.73, but it underscored the value of being explicit
-		// about tunnel configuration rather than relying on implicit defaults.
 		EncapLimit: 0,
 		Flags:      uint32(netlink.IP6_TNL_F_IGN_ENCAP_LIMIT),
 	}

--- a/pkg/network/link.go
+++ b/pkg/network/link.go
@@ -22,6 +22,30 @@ const (
 	ScopeLink     = 253
 )
 
+// DetectTunnelMTU returns the MTU for the VPN tunnel device by finding the
+// highest-MTU UP non-loopback link (i.e. eth0 in a container) and subtracting
+// the given overhead for VPN encapsulation.
+func DetectTunnelMTU(overhead int) (int, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list links: %w", err)
+	}
+	best := 0
+	for _, l := range links {
+		attrs := l.Attrs()
+		if attrs.Flags&net.FlagLoopback != 0 || attrs.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if attrs.MTU > best {
+			best = attrs.MTU
+		}
+	}
+	if best == 0 {
+		return 0, fmt.Errorf("no usable network interface found")
+	}
+	return best - overhead, nil
+}
+
 // DeleteLinkByName delete a link by name.
 func DeleteLinkByName(name string) error {
 	link, err := netlink.LinkByName(name)

--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/gardener/vpn2/pkg/constants"
+)
+
+// GetDefaultMTU returns the MTU of the default route of the pod.
+func GetDefaultMTU() (int, error) {
+
+	// Get default route
+	_, defaultIPv4, _ := net.ParseCIDR("0.0.0.0/0")
+	_, defaultIPv6, _ := net.ParseCIDR("::/0")
+
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return 0, fmt.Errorf("failed to list network routes: %w", err)
+	}
+
+	var defaultRoute *netlink.Route
+	for _, route := range routes {
+		if route.Dst != nil && route.Dst.String() == defaultIPv4.String() || route.Dst.String() == defaultIPv6.String() {
+			defaultRoute = &route
+			break
+		}
+	}
+
+	if defaultRoute == nil {
+		return 0, fmt.Errorf("failed to find default route: %w", err)
+	}
+
+	// Get route interface
+	defaultInterface, err := netlink.LinkByIndex(defaultRoute.LinkIndex)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find default route interface: %w", err)
+	}
+
+	return defaultInterface.Attrs().MTU, nil
+}
+
+// DetectTunnelMTU returns the MTU for the VPN tunnel device by finding the
+// MTU of the default route device (i.e. eth0 in a container) and subtracting
+// the given overhead for VPN encapsulation.
+func DetectTunnelMTU(overhead int) (int, error) {
+	defaultMTU, err := GetDefaultMTU()
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to detect tunnel MTU: %w", err)
+	}
+
+	tunnelMTU := defaultMTU - overhead
+
+	// Make sure we never go below IPv6 viability
+	if tunnelMTU < constants.MinimumMTU {
+		tunnelMTU = constants.MinimumMTU
+	}
+
+	return tunnelMTU, nil
+}

--- a/pkg/network/mtu.go
+++ b/pkg/network/mtu.go
@@ -1,8 +1,11 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/vishvananda/netlink"
 
@@ -12,25 +15,9 @@ import (
 // GetDefaultMTU returns the MTU of the default route of the pod.
 func GetDefaultMTU() (int, error) {
 
-	// Get default route
-	_, defaultIPv4, _ := net.ParseCIDR("0.0.0.0/0")
-	_, defaultIPv6, _ := net.ParseCIDR("::/0")
-
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	defaultRoute, err := getDefaultRoute()
 	if err != nil {
-		return 0, fmt.Errorf("failed to list network routes: %w", err)
-	}
-
-	var defaultRoute *netlink.Route
-	for _, route := range routes {
-		if route.Dst != nil && route.Dst.String() == defaultIPv4.String() || route.Dst.String() == defaultIPv6.String() {
-			defaultRoute = &route
-			break
-		}
-	}
-
-	if defaultRoute == nil {
-		return 0, fmt.Errorf("failed to find default route: %w", err)
+		return 0, err
 	}
 
 	// Get route interface

--- a/pkg/network/mtu_test.go
+++ b/pkg/network/mtu_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package network
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+
+	"github.com/gardener/vpn2/pkg/constants"
+)
+
+var _ = Describe("MTU", Serial, func() {
+	Describe("GetDefaultMTU", func() {
+		It("returns the MTU of the default route interface", func() {
+			mtu, err := GetDefaultMTU()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mtu).To(BeNumerically(">", 0))
+		})
+
+		It("returns an error if no default route was found", func() {
+			defaultRoute, err := getDefaultRoute()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Temporarily remove the default route
+			err = netlink.RouteDel(defaultRoute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = GetDefaultMTU()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find default route"))
+
+			// Restore the default route
+			err = netlink.RouteAdd(defaultRoute)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("DetectTunnelMTU", func() {
+		It("subtracts the overhead from the default MTU", func() {
+			defaultMTU, err := GetDefaultMTU()
+			Expect(err).NotTo(HaveOccurred())
+
+			overhead := 100
+			expected := defaultMTU - overhead
+			if expected < constants.MinimumMTU {
+				expected = constants.MinimumMTU
+			}
+
+			mtu, err := DetectTunnelMTU(overhead)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mtu).To(Equal(expected))
+		})
+
+		It("never returns less than the minimum MTU", func() {
+			defaultMTU, err := GetDefaultMTU()
+			Expect(err).NotTo(HaveOccurred())
+
+			overhead := defaultMTU - 100
+			mtu, err := DetectTunnelMTU(overhead)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mtu).To(Equal(constants.MinimumMTU))
+		})
+	})
+})

--- a/pkg/network/route.go
+++ b/pkg/network/route.go
@@ -11,6 +11,33 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+func getDefaultRoute() (*netlink.Route, error) {
+	_, defaultIPv4, _ := net.ParseCIDR("0.0.0.0/0")
+	_, defaultIPv6, _ := net.ParseCIDR("::/0")
+
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network routes: %w", err)
+	}
+
+	var defaultRoute *netlink.Route
+	for _, route := range routes {
+		if route.Dst != nil {
+			if route.Dst.String() == defaultIPv4.String() || route.Dst.String() == defaultIPv6.String() {
+				defaultRoute = &route
+				break
+			}
+		}
+	}
+
+	if defaultRoute == nil {
+		return nil, fmt.Errorf("failed to find default route")
+	}
+
+	return defaultRoute, nil
+}
+
+
 func routeForNetwork(net *net.IPNet, device netlink.Link) netlink.Route {
 	// ip route replace $net dev $device
 	route := netlink.Route{

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -5,9 +5,14 @@ auth-nocache
 
 # Additional optimizations
 txqueuelen 1000
+tcp-nodelay
+sndbuf 134217728
+rcvbuf 134217728
+
 {{- if .TunMTU }}
 tun-mtu {{ .TunMTU }}
 {{- end }}
+
 # get all routing information from server
 pull
 data-ciphers AES-256-GCM

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -5,6 +5,9 @@ auth-nocache
 
 # Additional optimizations
 txqueuelen 1000
+{{- if .TunMTU }}
+tun-mtu {{ .TunMTU }}
+{{- end }}
 # get all routing information from server
 pull
 data-ciphers AES-256-GCM
@@ -45,7 +48,12 @@ http-proxy-option CUSTOM-HEADER {{ .ReversedVPNHeaderKey }} {{ .ReversedVPNHeade
 dev {{ .Device }}
 remote {{ .Endpoint }}
 
-{{- if and .IsShootClient (not .IsHA) }}
+{{- if .IsShootClient }}
 script-security 2
+{{- if .IsHA }}
+up "/bin/sh -c '/sbin/ip link set dev bond0 mtu $2' -- "
+up-restart
+{{- else }}
 up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
+{{- end }}
 {{- end }}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -53,12 +53,7 @@ http-proxy-option CUSTOM-HEADER {{ .ReversedVPNHeaderKey }} {{ .ReversedVPNHeade
 dev {{ .Device }}
 remote {{ .Endpoint }}
 
-{{- if .IsShootClient }}
+{{- if and .IsShootClient (not .IsHA) }}
 script-security 2
-{{- if .IsHA }}
-up "/bin/sh -c '/sbin/ip link set dev bond0 mtu $2' -- "
-up-restart
-{{- else }}
 up "/bin/sh -c '/sbin/ip route replace {{ .SeedPodNetwork }} dev $1' -- "
-{{- end }}
 {{- end }}

--- a/pkg/openvpn/assets/client-config.template
+++ b/pkg/openvpn/assets/client-config.template
@@ -6,8 +6,6 @@ auth-nocache
 # Additional optimizations
 txqueuelen 1000
 tcp-nodelay
-sndbuf 134217728
-rcvbuf 134217728
 
 {{- if .TunMTU }}
 tun-mtu {{ .TunMTU }}

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -5,6 +5,10 @@ topology subnet
 
 # Additional optimizations
 txqueuelen 1000
+{{- if .TunMTU }}
+tun-mtu {{ .TunMTU }}
+push "tun-mtu {{ .TunMTU }}"
+{{- end }}
 
 data-ciphers AES-256-GCM:AES-256-CBC
 

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -5,6 +5,10 @@ topology subnet
 
 # Additional optimizations
 txqueuelen 1000
+tcp-nodelay
+sndbuf 134217728
+rcvbuf 134217728
+
 {{- if .TunMTU }}
 tun-mtu {{ .TunMTU }}
 push "tun-mtu {{ .TunMTU }}"

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -6,8 +6,6 @@ topology subnet
 # Additional optimizations
 txqueuelen 1000
 tcp-nodelay
-sndbuf 134217728
-rcvbuf 134217728
 
 {{- if .TunMTU }}
 tun-mtu {{ .TunMTU }}

--- a/pkg/openvpn/config_client.go
+++ b/pkg/openvpn/config_client.go
@@ -26,6 +26,7 @@ type ClientValues struct {
 	Device               string
 	SeedPodNetwork       string
 	IsDualStack          bool
+	TunMTU               int
 }
 
 func generateClientConfig(cfg ClientValues) (string, error) {

--- a/pkg/openvpn/config_client_test.go
+++ b/pkg/openvpn/config_client_test.go
@@ -144,13 +144,6 @@ cert /srv/secrets/vpn-client-0/tls.crt
 ca /srv/secrets/vpn-client-0/ca.crt
 `))
 				})
-				It("syncs bond MTU on tunnel up", func() {
-					Expect(content).To(ContainSubstring(`
-script-security 2
-up "/bin/sh -c '/sbin/ip link set dev bond0 mtu $2' -- "
-up-restart
-`))
-				})
 			})
 		})
 

--- a/pkg/openvpn/config_client_test.go
+++ b/pkg/openvpn/config_client_test.go
@@ -79,7 +79,7 @@ up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
 			})
 		})
 
-		Context("ipv4 HA config", func() {
+		Context("ipv4 non-HA shoot client config", func() {
 			cfg := ClientValues{
 				Endpoint:          "123.123.0.0",
 				VPNClientIndex:    0,
@@ -111,6 +111,44 @@ ca /srv/secrets/vpn-client-0/ca.crt
 					Expect(content).To(ContainSubstring(`
 script-security 2
 up "/bin/sh -c '/sbin/ip route replace 10.123.0.0/19 dev $1' -- "
+`))
+				})
+			})
+		})
+
+		Context("ipv4 HA shoot client config", func() {
+			cfg := ClientValues{
+				Endpoint:          "123.123.0.0",
+				VPNClientIndex:    0,
+				IPFamily:          "IPv4",
+				OpenVPNPort:       1143,
+				ReversedVPNHeader: "invalid-host",
+				IsShootClient:     true,
+				IsHA:              true,
+				SeedPodNetwork:    "10.123.0.0/19",
+			}
+
+			content, err := generateClientConfig(cfg)
+			It("does not error creating the template", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Describe("generated config contain check", func() {
+				It("proto tcp4-client", func() {
+					Expect(content).To(ContainSubstring(`proto tcp4-client`))
+				})
+				It("tls config", func() {
+					Expect(content).To(ContainSubstring(`
+key /srv/secrets/vpn-client-0/tls.key
+cert /srv/secrets/vpn-client-0/tls.crt
+ca /srv/secrets/vpn-client-0/ca.crt
+`))
+				})
+				It("syncs bond MTU on tunnel up", func() {
+					Expect(content).To(ContainSubstring(`
+script-security 2
+up "/bin/sh -c '/sbin/ip link set dev bond0 mtu $2' -- "
+up-restart
 `))
 				})
 			})

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -33,6 +33,7 @@ type SeedServerValues struct {
 	IsHA            bool
 	VPNIndex        int
 	LocalNodeIP     string
+	TunMTU          int
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/vpn_client/bonding.go
+++ b/pkg/vpn_client/bonding.go
@@ -20,6 +20,16 @@ import (
 )
 
 func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClient) error {
+	tunnelMTU := 0
+	if cfg.AutoMTU {
+		var mtuErr error
+		tunnelMTU, mtuErr = network.DetectTunnelMTU(constants.TunnelMTUOverhead)
+		if mtuErr != nil {
+			return fmt.Errorf("failed to detect tunnel MTU: %w", mtuErr)
+		}
+	}
+
+	var err error
 	var addr *net.IPNet
 
 	if cfg.IsShootClient {
@@ -66,11 +76,17 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 		if err != nil {
 			return err
 		}
+
+		if tunnelMTU > 0 {
+			if err = netlink.LinkSetMTU(linkDev, tunnelMTU); err != nil {
+				return fmt.Errorf("failed to set MTU on %s: %w", linkName, err)
+			}
+		}
 	}
 
 	// check if bond device already exists and delete it if exists
 	log.Info("deleting existing bond device if any", "link", constants.BondDevice)
-	err := network.DeleteLinkByName(constants.BondDevice)
+	err = network.DeleteLinkByName(constants.BondDevice)
 	if err != nil {
 		return err
 	}
@@ -124,6 +140,14 @@ func ConfigureBonding(ctx context.Context, log logr.Logger, cfg *config.VPNClien
 		err = netlink.LinkSetMaster(link, bond)
 		if err != nil {
 			return fmt.Errorf("failed to set %s as master for link %s: %w", constants.BondDevice, linkName, err)
+		}
+	}
+
+	// Set bond MTU after all slaves are added; the first enslave can reset the bond MTU
+	// to the slave's default if the kernel bonding driver inherits it from the first slave.
+	if tunnelMTU > 0 {
+		if err = netlink.LinkSetMTU(bond, tunnelMTU); err != nil {
+			return fmt.Errorf("failed to set MTU on %s: %w", constants.BondDevice, err)
 		}
 	}
 

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -74,6 +74,52 @@ func EnableIPForwarding() error {
 	return nil
 }
 
+// ConntrackSettings adjusts vpn-shoot for optimized performance with high connection churn and NAT.
+func ConntrackSettings() error {
+	// Increase local port range
+	if err := sysctl.Set("net.ipv4.ip_local_port_range", "1024 65535"); err != nil {
+		return err
+	}
+	// Reuse time_wait connections
+	if err := sysctl.Set("net.ipv4.tcp_tw_reuse", "1"); err != nil {
+		return err
+	}
+	// Reduce tcp fin timeout (from 60s)
+	if err := sysctl.Set("net.ipv4.tcp_fin_timeout", "30"); err != nil {
+		return err
+	}
+	// Reduce tcp_timeout_established to 10m (from 5 days)
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_established", "600"); err != nil {
+		return err
+	}
+	// Reduce syn timeouts (from 120s)
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_syn_sent", "30"); err != nil {
+		return err
+	}
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_syn_recv", "30"); err != nil {
+		return err
+	}
+	// Reduce time_wait etc. cleanup time (from 120s/60s)
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_fin_wait", "30"); err != nil {
+		return err
+	}
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_time_wait", "30"); err != nil {
+		return err
+	}
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_close_wait", "30"); err != nil {
+		return err
+	}
+	// Reduce retransmission timeouts (from 300s)
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_unacknowledged", "60"); err != nil {
+		return err
+	}
+	if err := sysctl.Set("net.netfilter.nf_conntrack_tcp_timeout_max_retrans", "120"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // KernelSettings sets the kernel parameters required for the VPN tunnel to function properly.
 func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	// Disable martian logging on both sides.
@@ -88,6 +134,12 @@ func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	if !cfg.IsShootClient {
 		return EnableIPv6Networking(log)
 	}
+
+	// Configure conntrack for nat on the shoot clients
+	if err := ConntrackSettings(); err != nil {
+		return err
+	}
+
 	// For shoot clients, we need to enable IP forwarding to be able to route traffic from the tunnel to the shoot cluster and back.
 	return EnableIPForwarding()
 }

--- a/pkg/vpn_client/sysctl_test.go
+++ b/pkg/vpn_client/sysctl_test.go
@@ -182,5 +182,54 @@ var _ = Describe("KernelSettings", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(value).To(Equal("0"))
 		})
+
+		It("should apply conntrack optimizations", func() {
+			err := KernelSettings(log, cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			value, err := sysctl.Get("net.ipv4.ip_local_port_range")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("1024\t65535"))
+
+			value, err = sysctl.Get("net.ipv4.tcp_tw_reuse")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("1"))
+
+			value, err = sysctl.Get("net.ipv4.tcp_fin_timeout")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_established")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("600"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_syn_sent")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_syn_recv")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_fin_wait")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_time_wait")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_close_wait")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("30"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_unacknowledged")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("60"))
+
+			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_max_retrans")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("120"))
+		})
 	})
 })

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -22,6 +22,14 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		StatusPath: cfg.StatusPath,
 	}
 
+	if cfg.AutoMTU {
+		tunMTU, err := network.DetectTunnelMTU(constants.TunnelMTUOverhead)
+		if err != nil {
+			return v, fmt.Errorf("failed to detect tunnel MTU: %w", err)
+		}
+		v.TunMTU = tunMTU
+	}
+
 	if cfg.VPNNetwork.IP == nil {
 		return v, fmt.Errorf("VPN_NETWORK must be set")
 	}

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -22,14 +22,6 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		StatusPath: cfg.StatusPath,
 	}
 
-	if cfg.AutoMTU {
-		tunMTU, err := network.DetectTunnelMTU(constants.TunnelMTUOverhead)
-		if err != nil {
-			return v, fmt.Errorf("failed to detect tunnel MTU: %w", err)
-		}
-		v.TunMTU = tunMTU
-	}
-
 	if cfg.VPNNetwork.IP == nil {
 		return v, fmt.Errorf("VPN_NETWORK must be set")
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
By default the OpenVPN tunnel uses the OpenVPN default MTU (1500 bytes). In environments where the underlying
network supports a larger MTU (e.g. clusters connected via a high-speed backbone with jumbo frames), configuring
a larger tunnel MTU can significantly improve throughput and reduce latency — in particular for geographically
distant seed/shoot pairs.
Set `OPENVPN_AUTO_MTU=true` on both **vpn-seed-server** and **vpn-client** to enable automatic MTU detection:
```
OPENVPN_AUTO_MTU=true
```
At startup each component scans its network interfaces, takes the MTU of the highest-MTU UP non-loopback
interface (typically `eth0`), and derives the tunnel MTU by subtracting a fixed overhead of 130 bytes
(IPv6 header 40 B + TCP header 40 B + OpenVPN AES-256-GCM/tls framing ≈ 50 B). With a typical container
network MTU of `8930` this yields a tunnel MTU of `8800`. Leave the variable unset (default `false`) to keep
the OpenVPN default and avoid any change in behaviour for standard environments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/kind enhancement

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Added OPENVPN_AUTO_MTU environment variable for vpn-seed-server and vpn-client. When enabled, the VPN tunnel MTU is automatically derived from the underlying network interface MTU, improving throughput and preventing connection resets in geographically distant seed/shoot pairs with jumbo-frame networks.
```
