### PR TITLE
Openvpn 2.7 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ RUN    cp -d /lib/ld-musl-* ./lib                                           && e
     && cp -d /usr/sbin/openvpn ./usr/sbin                                   && echo package openvpn \
     && cp -d /etc/openvpn/* ./etc/openvpn                                   && echo package openvpn \
     && cp -d /usr/lib/openvpn/plugins/openvpn* ./usr/lib/openvpn/plugins    && echo package openvpn \
+    && cp -d /usr/lib/libnl-3.so.* ./usr/lib                                && echo package openvpn \
+    && cp -d /usr/lib/libnl-genl-3.so.* ./usr/lib                           && echo package openvpn \
+    && cp -d /usr/lib/libpkcs11-helper.so.* ./usr/lib                       && echo package openvpn \
     && cp -d /usr/lib/libnftnl* ./usr/lib                                   && echo package libnftnl \
     && cp -d /etc/ethertypes ./etc                                          && echo package iptables \
     && cp -d /usr/sbin/iptables* ./usr/sbin                                 && echo package iptables \
@@ -61,8 +64,7 @@ RUN if [ "$DEBUG" = "true" ]; then \
        && cp -d /usr/lib/libpcap* ./usr/lib                                 && echo package tcpdump \
        && cp -d /usr/lib/libcurl* ./usr/lib                                 && echo package curl \
        && cp -d /usr/lib/libcares* ./usr/lib                                && echo package curl \
-       && cp -d /usr/lib/libnghttp2* ./usr/lib                              && echo package curl \
-       && cp -d /usr/lib/libnghttp3* ./usr/lib                              && echo package curl \
+       && cp -d /usr/lib/libnghttp* ./usr/lib                               && echo package curl \
        && cp -d /usr/lib/libidn2* ./usr/lib                                 && echo package curl \
        && cp -d /usr/lib/libpsl* ./usr/lib                                  && echo package curl \
        && cp -d /usr/lib/libbrotlidec* ./usr/lib                            && echo package curl \
@@ -99,6 +101,7 @@ FROM scratch AS vpn-client
 COPY --from=base /volume /
 COPY --from=gobuilder-vpn-client /build/bin/vpn-client /bin/vpn-client
 COPY --from=gobuilder-vpn-client /build/bin/tunnel-controller /bin/tunnel-controller
+RUN openvpn --version
 ENTRYPOINT /bin/vpn-client && openvpn --config /openvpn-client.config
 
 ## gobuilder-vpn-server
@@ -110,4 +113,5 @@ RUN --mount=type=cache,target="/root/.cache/go-build" make build-vpn-server ARCH
 FROM scratch AS vpn-server
 COPY --from=base /volume /
 COPY --from=gobuilder-vpn-server /build/bin/vpn-server /bin/vpn-server
+RUN openvpn --version
 ENTRYPOINT /bin/vpn-server && openvpn --config /openvpn-server.config

--- a/pkg/openvpn/health/status.go
+++ b/pkg/openvpn/health/status.go
@@ -243,10 +243,11 @@ func parseRealClientAddress(addrStr string) (netip.AddrPort, error) {
 	// - IPv6 (e.g., 2001:db8::1) (no port)
 	// In OpenVPN 2.7 the format is always IP:Port, even for IPv6 (e.g., [2001:db8::1]:1234) but it may be prefixed by
 	// the protocol (e.g., udp6:[2001:db8::1]:1234)
+	// or the protocol type (e.g., tcp4-server:100.64.5.13:47764
 	// See https://github.com/OpenVPN/openvpn/issues/963
 
 	// Parse using regexp to handle both formats
-	regex := `^(?:(?:udp|tcp)(?:4|6)?\:)?(\[?[a-fA-F0-9:.]+\]?)?(?::(\d+))?$`
+	regex := `^(?:(?:udp|tcp)(?:4|6)?(?:-(?:client|server))?\:)?(\[?[a-fA-F0-9:.]+\]?)?(?::(\d+))?$`
 	re := regexp.MustCompile(regex)
 	matches := re.FindStringSubmatch(addrStr)
 	if len(matches) == 0 {

--- a/pkg/openvpn/health/status_test.go
+++ b/pkg/openvpn/health/status_test.go
@@ -189,6 +189,42 @@ var _ = Describe("OpenVPN Server Status", func() {
 		})
 	})
 
+	Context("2.7 server with shoot client (non-HA)", func() {
+		BeforeEach(func() {
+			status, err = ParseFile(`test/openvpn27-nonha-ready.status`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).ToNot(BeNil())
+			status.UpdatedAt = time.Now().Add(-2 * time.Second)
+		})
+
+		It("should report vpn-server as up", func() {
+			Expect(isUp(log, status, 15)).To(BeTrue())
+		})
+		It("should have one client", func() {
+			Expect(len(status.Clients)).To(Equal(1))
+		})
+		It("should have parsed clients correctly", func() {
+			Expect(status.Clients[0].RealAddress.Addr().String()).To(Equal("100.64.5.13"))
+		})
+		It("should have routing entries", func() {
+			Expect(len(status.RoutingTable)).To(BeNumerically(">", 0))
+		})
+		It("should have parsed routing entries correctly", func() {
+			Expect(status.RoutingTable[0].RealAddress.Addr().String()).To(Equal("100.64.5.13"))
+			Expect(status.RoutingTable[0].VirtualAddress).To(Equal("243.0.0.0/8"))
+			Expect(status.RoutingTable[1].RealAddress.Addr().String()).To(Equal("100.64.5.13"))
+			Expect(status.RoutingTable[1].VirtualAddress).To(Equal("242.0.140.197C"))
+			Expect(status.RoutingTable[2].RealAddress.Addr().String()).To(Equal("100.64.5.13"))
+			Expect(status.RoutingTable[2].VirtualAddress).To(Equal("242.0.0.0/8"))
+		})
+		It("should be ready (non-HA)", func() {
+			Expect(isReady(log, status, false)).To(BeTrue())
+		})
+		It("should not be ready (HA)", func() {
+			Expect(isReady(log, status, true)).To(BeFalse())
+		})
+	})
+
 	Context("server with only shoot clients", func() {
 		BeforeEach(func() {
 			status, err = ParseFile(`test/openvpn-nonha-ready.status`)

--- a/pkg/openvpn/health/test/openvpn27-nonha-ready.status
+++ b/pkg/openvpn/health/test/openvpn27-nonha-ready.status
@@ -1,0 +1,20 @@
+TITLE,OpenVPN 2.7.3 x86_64-alpine-linux-musl [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [PKCS11] [MH/PKTINFO] [AEAD] [DCO]
+TIME,2026-06-10 09:45:02,1781084702
+HEADER,CLIENT_LIST,Common Name,Real Address,Virtual Address,Virtual IPv6 Address,Bytes Received,Bytes Sent,Connected Since,Connected Since (time_t),Username,Client ID,Peer ID,Data Channel Cipher
+CLIENT_LIST,vpn-shoot-client,tcp6-server:100.64.5.13:47764,,fd8f:6d53:b97a:1::1000,225040,28752,2026-06-10 09:44:49,1781084689,UNDEF,0,0,AES-256-GCM
+HEADER,ROUTING_TABLE,Virtual Address,Common Name,Real Address,Last Ref,Last Ref (time_t)
+ROUTING_TABLE,243.0.0.0/8,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:51,1781084691
+ROUTING_TABLE,242.0.140.197C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:59,1781084699
+ROUTING_TABLE,242.0.0.0/8,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:51,1781084691
+ROUTING_TABLE,244.0.1.3C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:52,1781084692
+ROUTING_TABLE,242.0.153.44C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:58,1781084698
+ROUTING_TABLE,244.0.1.6C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:45:00,1781084700
+ROUTING_TABLE,fd8f:6d53:b97a:1::1000,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:51,1781084691
+ROUTING_TABLE,244.0.0.0/8,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:51,1781084691
+ROUTING_TABLE,242.0.131.32C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:59,1781084699
+ROUTING_TABLE,242.0.129.206C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:45:01,1781084701
+ROUTING_TABLE,244.0.1.8C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:59,1781084699
+ROUTING_TABLE,244.0.2.2C,vpn-shoot-client,tcp6-server:100.64.5.13:47764,2026-06-10 09:44:52,1781084692
+GLOBAL_STATS,Max bcast/mcast queue length,1
+GLOBAL_STATS,dco_enabled,0
+END


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- A [recent PR](https://github.com/gardener/vpn2/pull/293) has bumped OpenVPN to 2.7
- The new version requires additional libs which are included in this PR
- Also, run the openvpn binary during the build to test if it actually works (this would have caused the above PR to not be merged as it produced a non-working binary due to missing libs)
- The openvpn status file format has changed slightly with 2.7. Adapt the status file parser accordingly and add a test for it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
OpenVPN was updated to v2.7. Code base was adjusted accordingly.
```
