### PR TITLE
Route table limits

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,6 +37,9 @@ const (
 	ShootNodeNetworkMapped    = constants.ReservedShootNodeNetworkMappedRange
 	SeedPodNetworkMapped      = constants.ReservedSeedPodNetworkMappedRange
 
+	// MaxRoutesPerClientLimit is the maximum number of route table entries for a vpn client
+	MaxRoutesPerClientLimit = 1 << 16
+
 	PathControllerUpdateInterval  = 2 * time.Second
 	TunnelControllerUpdateTimeout = 2 * PathControllerUpdateInterval
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,8 +37,8 @@ const (
 	ShootNodeNetworkMapped    = constants.ReservedShootNodeNetworkMappedRange
 	SeedPodNetworkMapped      = constants.ReservedSeedPodNetworkMappedRange
 
-	// MaxRoutesPerClientLimit is the maximum number of route table entries for a vpn client
-	MaxRoutesPerClientLimit = 1 << 16
+	RoutesPerClientMax = 1 << 16
+	RoutesPerClientMin = 256
 
 	PathControllerUpdateInterval  = 2 * time.Second
 	TunnelControllerUpdateTimeout = 2 * PathControllerUpdateInterval

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,8 +37,9 @@ const (
 	ShootNodeNetworkMapped    = constants.ReservedShootNodeNetworkMappedRange
 	SeedPodNetworkMapped      = constants.ReservedSeedPodNetworkMappedRange
 
-	RoutesPerClientMax = 1 << 16
-	RoutesPerClientMin = 256
+	// RoutesPerClientMax is the upper limit for route table entries. One entry estimated at ~50 bytes of memory.
+	RoutesPerClientMax = 1 << 20 // 1 million routes (~50MB) per client.
+	RoutesPerClientMin = 256     // OpenVPN default
 
 	PathControllerUpdateInterval  = 2 * time.Second
 	TunnelControllerUpdateTimeout = 2 * PathControllerUpdateInterval

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -52,6 +52,15 @@ func (c *CIDR) IsIPv4() bool {
 	return c.IP.To4() != nil
 }
 
+func (c *CIDR) CountHosts() int {
+	ones, bits := c.Mask.Size()
+	hostBits := bits - ones
+	if hostBits <= 0 {
+		return 0
+	}
+	return (1 << hostBits) - 2 // Subtract network and broadcast addresses
+}
+
 // ParseIPNet parses a CIDR string and returns a network.CIDR (for user-provided values)
 func ParseIPNet(cidr string) (CIDR, error) {
 	_, prefix, err := net.ParseCIDR(cidr)

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -52,6 +52,7 @@ func (c *CIDR) IsIPv4() bool {
 	return c.IP.To4() != nil
 }
 
+// CountHosts returns the number of addressable host IPs in a CIDR
 func (c *CIDR) CountHosts() int {
 	ones, bits := c.Mask.Size()
 	hostBits := bits - ones

--- a/pkg/network/types.go
+++ b/pkg/network/types.go
@@ -6,6 +6,7 @@ package network
 
 import (
 	"fmt"
+	"math/big"
 	"net"
 )
 
@@ -53,13 +54,26 @@ func (c *CIDR) IsIPv4() bool {
 }
 
 // CountHosts returns the number of addressable host IPs in a CIDR
-func (c *CIDR) CountHosts() int {
+func (c *CIDR) CountHosts() *big.Int {
 	ones, bits := c.Mask.Size()
-	hostBits := bits - ones
-	if hostBits <= 0 {
-		return 0
+	if ones < 0 || bits <= 0 || ones > bits {
+		return big.NewInt(0)
 	}
-	return (1 << hostBits) - 2 // Subtract network and broadcast addresses
+
+	// total = 2^(hostBits)
+	hostBits := bits - ones
+	total := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+
+	// IPv4: subtract network and broadcast for traditional subnets.
+	// /31 and /32 are special cases where no subtraction is applied.
+	if bits == 32 && ones <= 30 {
+		if total.Cmp(big.NewInt(2)) >= 0 {
+			return new(big.Int).Sub(total, big.NewInt(2))
+		}
+		return big.NewInt(0)
+	}
+
+	return total
 }
 
 // ParseIPNet parses a CIDR string and returns a network.CIDR (for user-provided values)

--- a/pkg/network/types_test.go
+++ b/pkg/network/types_test.go
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("types", func() {
+	Describe("CIDR", func() {
+		Describe("Equal", func() {
+			It("returns true for equal CIDRs", func() {
+				a := ParseIPNetIgnoreError("10.10.0.0/24")
+				b := ParseIPNetIgnoreError("10.10.0.0/24")
+
+				Expect(a.Equal(b)).To(BeTrue())
+			})
+
+			It("returns false for different CIDRs", func() {
+				a := ParseIPNetIgnoreError("10.10.0.0/24")
+				b := ParseIPNetIgnoreError("10.10.0.0/25")
+
+				Expect(a.Equal(b)).To(BeFalse())
+			})
+		})
+
+		Describe("UnmarshalText", func() {
+			It("accepts empty input", func() {
+				cidr := CIDR{}
+
+				Expect(cidr.UnmarshalText([]byte(""))).To(Succeed())
+				Expect(cidr.String()).To(Equal(""))
+			})
+
+			It("parses a valid CIDR", func() {
+				cidr := CIDR{}
+
+				Expect(cidr.UnmarshalText([]byte("10.20.0.0/16"))).To(Succeed())
+				Expect(cidr.String()).To(Equal("10.20.0.0/16"))
+			})
+
+			It("returns an error for invalid CIDR input", func() {
+				cidr := CIDR{}
+
+				Expect(cidr.UnmarshalText([]byte("invalid"))).To(HaveOccurred())
+			})
+		})
+
+		Describe("String", func() {
+			It("returns empty string for zero-value CIDR", func() {
+				Expect((CIDR{}).String()).To(Equal(""))
+			})
+
+			It("returns canonical cidr string", func() {
+				cidr := ParseIPNetIgnoreError("192.168.1.0/24")
+
+				Expect(cidr.String()).To(Equal("192.168.1.0/24"))
+			})
+		})
+
+		Describe("ToIPNet", func() {
+			It("returns an equivalent net.IPNet", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.0/8")
+
+				ipNet := cidr.ToIPNet()
+				Expect(ipNet).NotTo(BeNil())
+				Expect(ipNet.IP.Equal(cidr.IP)).To(BeTrue())
+				Expect(ipNet.Mask.String()).To(Equal(cidr.Mask.String()))
+			})
+		})
+
+		Describe("IsIPv4", func() {
+			It("returns true for IPv4 CIDR", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.0/24")
+				Expect(cidr.IsIPv4()).To(BeTrue())
+			})
+
+			It("returns false for IPv6 CIDR", func() {
+				cidr := ParseIPNetIgnoreError("2001:db8::/64")
+				Expect(cidr.IsIPv4()).To(BeFalse())
+			})
+		})
+
+		Describe("CountHosts", func() {
+			It("returns host count for subnet", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.0/24")
+				Expect(cidr.CountHosts()).To(Equal(254))
+			})
+
+			It("returns host count for IPv6 subnet", func() {
+				cidr := ParseIPNetIgnoreError("2001:db8::/126")
+				Expect(cidr.CountHosts()).To(Equal(2))
+			})
+
+			It("returns zero for prefixes without host addresses", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.1/32")
+				Expect(cidr.CountHosts()).To(Equal(0))
+			})
+
+		})
+	})
+
+	Describe("ParseIPNet", func() {
+		It("parses valid CIDR", func() {
+			cidr, err := ParseIPNet("172.16.0.0/12")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cidr.String()).To(Equal("172.16.0.0/12"))
+		})
+
+		It("parses valid IPv6 CIDR", func() {
+			cidr, err := ParseIPNet("2001:db8::/64")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cidr.String()).To(Equal("2001:db8::/64"))
+		})
+
+		It("returns error for invalid input", func() {
+			_, err := ParseIPNet("invalid")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ParseIPNetIgnoreError", func() {
+		It("returns parsed CIDR for valid input", func() {
+			cidr := ParseIPNetIgnoreError("10.0.0.0/24")
+			Expect(cidr.String()).To(Equal("10.0.0.0/24"))
+		})
+
+		It("returns zero-value CIDR for invalid input", func() {
+			cidr := ParseIPNetIgnoreError("invalid")
+			Expect(cidr.String()).To(Equal(""))
+		})
+	})
+
+	Describe("GetByIPFamily", func() {
+		var cidrs []CIDR
+
+		BeforeEach(func() {
+			cidrs = []CIDR{
+				ParseIPNetIgnoreError("10.0.0.0/24"),
+				ParseIPNetIgnoreError("192.168.1.0/24"),
+				ParseIPNetIgnoreError("2001:db8::/64"),
+			}
+		})
+
+		It("returns only IPv4 cidrs", func() {
+			result := GetByIPFamily(cidrs, IPv4Family)
+
+			Expect(result).To(HaveLen(2))
+			for _, cidr := range result {
+				Expect(cidr.IP.To4()).NotTo(BeNil())
+			}
+		})
+
+		It("returns only IPv6 cidrs", func() {
+			result := GetByIPFamily(cidrs, IPv6Family)
+
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].IP.To4()).To(BeNil())
+		})
+
+		It("returns empty list for unknown family", func() {
+			result := GetByIPFamily(cidrs, "unknown")
+			Expect(result).To(BeEmpty())
+		})
+	})
+
+	Describe("Overlap", func() {
+		It("returns true for overlapping networks", func() {
+			a := ParseIPNetIgnoreError("10.0.0.0/24")
+			b := ParseIPNetIgnoreError("10.0.0.128/25")
+
+			Expect(Overlap(a, b)).To(BeTrue())
+		})
+
+		It("returns false for non-overlapping networks", func() {
+			a := ParseIPNetIgnoreError("10.0.0.0/24")
+			b := ParseIPNetIgnoreError("10.0.1.0/24")
+
+			Expect(Overlap(a, b)).To(BeFalse())
+		})
+
+		It("returns true for overlapping IPv6 networks", func() {
+			a := ParseIPNetIgnoreError("2001:db8::/64")
+			b := ParseIPNetIgnoreError("2001:db8::8000/65")
+
+			Expect(Overlap(a, b)).To(BeTrue())
+		})
+
+		It("returns false for non-overlapping IPv6 networks", func() {
+			a := ParseIPNetIgnoreError("2001:db8::/64")
+			b := ParseIPNetIgnoreError("2001:db8:1::/64")
+
+			Expect(Overlap(a, b)).To(BeFalse())
+		})
+	})
+
+	Describe("OverLapAny", func() {
+		It("returns true when any network overlaps", func() {
+			nw := ParseIPNetIgnoreError("10.0.0.0/24")
+			otherA := ParseIPNetIgnoreError("10.0.1.0/24")
+			otherB := ParseIPNetIgnoreError("10.0.0.128/25")
+
+			Expect(OverLapAny(nw, otherA, otherB)).To(BeTrue())
+		})
+
+		It("returns false when no networks overlap", func() {
+			nw := ParseIPNetIgnoreError("10.0.0.0/24")
+			otherA := ParseIPNetIgnoreError("10.0.1.0/24")
+			otherB := ParseIPNetIgnoreError("10.0.2.0/24")
+
+			Expect(OverLapAny(nw, otherA, otherB)).To(BeFalse())
+		})
+
+		It("returns true when any IPv6 network overlaps", func() {
+			nw := ParseIPNetIgnoreError("2001:db8::/64")
+			otherA := ParseIPNetIgnoreError("2001:db8:1::/64")
+			otherB := ParseIPNetIgnoreError("2001:db8::8000/65")
+
+			Expect(OverLapAny(nw, otherA, otherB)).To(BeTrue())
+		})
+
+		It("returns false when no IPv6 networks overlap", func() {
+			nw := ParseIPNetIgnoreError("2001:db8::/64")
+			otherA := ParseIPNetIgnoreError("2001:db8:1::/64")
+			otherB := ParseIPNetIgnoreError("2001:db8:2::/64")
+
+			Expect(OverLapAny(nw, otherA, otherB)).To(BeFalse())
+		})
+
+		It("returns false when no candidate networks are provided", func() {
+			nw := CIDR{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}
+			Expect(OverLapAny(nw)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/network/types_test.go
+++ b/pkg/network/types_test.go
@@ -5,6 +5,7 @@
 package network
 
 import (
+	"math/big"
 	"net"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -87,21 +88,35 @@ var _ = Describe("types", func() {
 		})
 
 		Describe("CountHosts", func() {
-			It("returns host count for subnet", func() {
+			It("returns 254 for a /24 IPv4 subnet", func() {
 				cidr := ParseIPNetIgnoreError("10.0.0.0/24")
-				Expect(cidr.CountHosts()).To(Equal(254))
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(254)))
 			})
 
-			It("returns host count for IPv6 subnet", func() {
+			It("returns 4 for a /126 IPv6 subnet (no broadcast or network subtraction)", func() {
 				cidr := ParseIPNetIgnoreError("2001:db8::/126")
-				Expect(cidr.CountHosts()).To(Equal(2))
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(4)))
 			})
 
-			It("returns zero for prefixes without host addresses", func() {
+			It("returns 1 for a /128 IPv6 subnet (single host)", func() {
+				cidr := ParseIPNetIgnoreError("2001:db8::/128")
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(1)))
+			})
+
+			It("returns 1 for a /32 subnet (single host)", func() {
 				cidr := ParseIPNetIgnoreError("10.0.0.1/32")
-				Expect(cidr.CountHosts()).To(Equal(0))
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(1)))
 			})
 
+			It("returns 2 for a /31 subnet (point-to-point)", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.0/31")
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(2)))
+			})
+
+			It("returns 2 for a /30 subnet (subtract broadcast and network)", func() {
+				cidr := ParseIPNetIgnoreError("10.0.0.0/31")
+				Expect(cidr.CountHosts()).To(Equal(big.NewInt(2)))
+			})
 		})
 	})
 

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -23,7 +23,7 @@ port 1194
 # this value is pushed to the client, timeout is doubled on the server side, so the client is considered down after 60 seconds without traffic
 keepalive 10 30
 
-# number of routes per client. routes go stale after 5 minutes, clean up every 10 minutes
+# max number of routes per client. routes go stale after 5 minutes, clean up every 10 minutes
 max-routes-per-client {{ .MaxRoutesPerClient }}
 stale-routes-check 300 600
 

--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -23,6 +23,10 @@ port 1194
 # this value is pushed to the client, timeout is doubled on the server side, so the client is considered down after 60 seconds without traffic
 keepalive 10 30
 
+# number of routes per client. routes go stale after 5 minutes, clean up every 10 minutes
+max-routes-per-client {{ .MaxRoutesPerClient }}
+stale-routes-check 300 600
+
 # client-config-dir to push client specific configuration
 client-config-dir /client-config-dir
 

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -22,18 +22,18 @@ var (
 )
 
 type SeedServerValues struct {
-	Device          string
-	StatusPath      string
-	OpenVPNNetwork  network.CIDR
-	ShootNetworks   []network.CIDR
-	ShootNetworksV4 []network.CIDR
-	ShootNetworksV6 []network.CIDR
-	SeedPodNetwork  network.CIDR
-	HAVPNClients    int
-	IsHA            bool
-	VPNIndex        int
-	LocalNodeIP     string
-	TunMTU          int
+	Device             string
+	StatusPath         string
+	OpenVPNNetwork     network.CIDR
+	ShootNetworks      []network.CIDR
+	ShootNetworksV4    []network.CIDR
+	ShootNetworksV6    []network.CIDR
+	SeedPodNetwork     network.CIDR
+	HAVPNClients       int
+	IsHA               bool
+	VPNIndex           int
+	LocalNodeIP        string
+	TunMTU             int
 	MaxRoutesPerClient int
 }
 

--- a/pkg/openvpn/config_server.go
+++ b/pkg/openvpn/config_server.go
@@ -34,6 +34,7 @@ type SeedServerValues struct {
 	VPNIndex        int
 	LocalNodeIP     string
 	TunMTU          int
+	MaxRoutesPerClient int
 }
 
 func generateSeedServerConfig(cfg SeedServerValues) (string, error) {

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -32,6 +32,19 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		return v, fmt.Errorf("invalid prefix length for VPN_NETWORK, must be /%d, vpn network: %s", constants.VPNNetworkMask, cfg.VPNNetwork)
 	}
 
+	// Set MaxRoutesPerClient to the size of the larget shoot network with an upper bound of MaxRoutesPerClientLimit
+	maxRoutes := 0
+	for _, shootNetwork := range slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks) {
+		routes := shootNetwork.CountHosts()
+		if routes > maxRoutes {
+			maxRoutes = routes
+		}
+	}
+	if maxRoutes > constants.MaxRoutesPerClientLimit {
+		maxRoutes = constants.MaxRoutesPerClientLimit
+	}
+	v.MaxRoutesPerClient = maxRoutes
+
 	v.IsHA, v.VPNIndex = getHAInfo(cfg)
 
 	if v.IsHA != cfg.IsHA {

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -6,6 +6,7 @@ package vpn_server
 
 import (
 	"fmt"
+	"math/big"
 	"regexp"
 	"slices"
 	"strconv"
@@ -33,20 +34,16 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 	}
 
 	// Set MaxRoutesPerClient to the size of the largest shoot network within RoutesPerClientMax and RoutesPerClientMin
-	maxRoutes := 0
+	maxRoutes := int64(0)
 	for _, shootNetwork := range slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks) {
 		routes := shootNetwork.CountHosts()
-		if routes > maxRoutes {
-			maxRoutes = routes
+		if routes != nil && routes.Cmp(big.NewInt(maxRoutes)) >= 0 {
+			maxRoutes = routes.Int64()
 		}
 	}
-	if maxRoutes > constants.RoutesPerClientMax {
-		maxRoutes = constants.RoutesPerClientMax
-	}
-	if maxRoutes < constants.RoutesPerClientMin {
-		maxRoutes = constants.RoutesPerClientMin
-	}
-	v.MaxRoutesPerClient = maxRoutes
+
+	maxRoutes = max(min(maxRoutes, constants.RoutesPerClientMax), constants.RoutesPerClientMin)
+	v.MaxRoutesPerClient = int(maxRoutes)
 
 	v.IsHA, v.VPNIndex = getHAInfo(cfg)
 

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -40,8 +40,11 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 			maxRoutes = routes
 		}
 	}
-	if maxRoutes > constants.MaxRoutesPerClientLimit {
-		maxRoutes = constants.MaxRoutesPerClientLimit
+	if maxRoutes > constants.RoutesPerClientMax {
+		maxRoutes = constants.RoutesPerClientMax
+	}
+	if maxRoutes < constants.RoutesPerClientMin {
+		maxRoutes = constants.RoutesPerClientMin
 	}
 	v.MaxRoutesPerClient = maxRoutes
 

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -33,17 +33,20 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		return v, fmt.Errorf("invalid prefix length for VPN_NETWORK, must be /%d, vpn network: %s", constants.VPNNetworkMask, cfg.VPNNetwork)
 	}
 
-	// Set MaxRoutesPerClient to the size of the largest shoot network within RoutesPerClientMax and RoutesPerClientMin
-	maxRoutes := int64(0)
+	// Set MaxRoutesPerClient to the sum of all shoot networks within RoutesPerClientMax and RoutesPerClientMin
+	maxRoutes := big.NewInt(0)
 	for _, shootNetwork := range slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks) {
-		routes := shootNetwork.CountHosts()
-		if routes != nil && routes.Cmp(big.NewInt(maxRoutes)) >= 0 {
-			maxRoutes = routes.Int64()
-		}
+		maxRoutes.Add(maxRoutes, shootNetwork.CountHosts())
 	}
-
-	maxRoutes = max(min(maxRoutes, constants.RoutesPerClientMax), constants.RoutesPerClientMin)
-	v.MaxRoutesPerClient = int(maxRoutes)
+	maxRoutesUint64 := uint64(0)
+	if maxRoutes.IsUint64() {
+		maxRoutesUint64 = maxRoutes.Uint64()
+	} else {
+		// if we are beyond uin64 we top out at max value
+		maxRoutesUint64 = constants.RoutesPerClientMax
+	}
+	maxRoutesUint64 = max(min(maxRoutesUint64, constants.RoutesPerClientMax), constants.RoutesPerClientMin)
+	v.MaxRoutesPerClient = int(maxRoutesUint64)
 
 	v.IsHA, v.VPNIndex = getHAInfo(cfg)
 

--- a/pkg/vpn_server/values.go
+++ b/pkg/vpn_server/values.go
@@ -32,7 +32,7 @@ func BuildValues(cfg config.VPNServer) (openvpn.SeedServerValues, error) {
 		return v, fmt.Errorf("invalid prefix length for VPN_NETWORK, must be /%d, vpn network: %s", constants.VPNNetworkMask, cfg.VPNNetwork)
 	}
 
-	// Set MaxRoutesPerClient to the size of the larget shoot network with an upper bound of MaxRoutesPerClientLimit
+	// Set MaxRoutesPerClient to the size of the largest shoot network within RoutesPerClientMax and RoutesPerClientMin
 	maxRoutes := 0
 	for _, shootNetwork := range slices.Concat(cfg.ShootPodNetworks, cfg.ShootServiceNetworks, cfg.ShootNodeNetworks) {
 		routes := shootNetwork.CountHosts()

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -408,7 +408,7 @@ var _ = Describe("BuildValues", func() {
 		})
 
 		It("should use the largest shoot network size", func() {
-			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/25")}    // 126 hosts
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/25")}     // 126 hosts
 			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.20.0.0/23")} // 510 hosts
 			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.30.0.0/24")}    // 254 hosts
 
@@ -440,7 +440,7 @@ var _ = Describe("BuildValues", func() {
 		})
 
 		It("should calculate MaxRoutesPerClient from IPv6 network sizes", func() {
-			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}   // 254 hosts
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}     // 254 hosts
 			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 510 hosts
 			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/126")}    // 2 hosts
 

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -441,12 +441,12 @@ var _ = Describe("BuildValues", func() {
 
 		It("should calculate MaxRoutesPerClient from IPv6 network sizes", func() {
 			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}     // 254 hosts
-			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 510 hosts
+			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 512 hosts
 			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/126")}    // 2 hosts
 
 			v, err := vpn_server.BuildValues(cfg)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(v.MaxRoutesPerClient).To(Equal(510))
+			Expect(v.MaxRoutesPerClient).To(Equal(512))
 		})
 	})
 })

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -400,4 +400,53 @@ var _ = Describe("BuildValues", func() {
 			})
 		})
 	})
+
+	Describe("MaxRoutesPerClient", func() {
+		BeforeEach(func() {
+			cfg.VPNNetwork = network.ParseIPNetIgnoreError("2001:db8::/96")
+			cfg.PodName = "vpn-seed-server-5d99b56fcb-2h58x"
+		})
+
+		It("should use the largest shoot network size", func() {
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/25")}    // 126 hosts
+			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.20.0.0/23")} // 510 hosts
+			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.30.0.0/24")}    // 254 hosts
+
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(510))
+		})
+
+		It("should cap MaxRoutesPerClient at RoutesPerClientMax", func() {
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/15")} // 131070 hosts
+
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMax))
+		})
+
+		It("should enforce RoutesPerClientMin when computed value is below minimum", func() {
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/30")} // 2 hosts
+
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMin))
+		})
+
+		It("should enforce RoutesPerClientMin when no shoot networks are configured", func() {
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMin))
+		})
+
+		It("should calculate MaxRoutesPerClient from IPv6 network sizes", func() {
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}   // 254 hosts
+			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 510 hosts
+			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/126")}    // 2 hosts
+
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(510))
+		})
+	})
 })

--- a/pkg/vpn_server/values_test.go
+++ b/pkg/vpn_server/values_test.go
@@ -407,18 +407,29 @@ var _ = Describe("BuildValues", func() {
 			cfg.PodName = "vpn-seed-server-5d99b56fcb-2h58x"
 		})
 
-		It("should use the largest shoot network size", func() {
+		It("should use the sum of all shoot network sizes", func() {
 			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/25")}     // 126 hosts
 			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.20.0.0/23")} // 510 hosts
 			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.30.0.0/24")}    // 254 hosts
 
 			v, err := vpn_server.BuildValues(cfg)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(v.MaxRoutesPerClient).To(Equal(510))
+			Expect(v.MaxRoutesPerClient).To(Equal(890))
 		})
 
 		It("should cap MaxRoutesPerClient at RoutesPerClientMax", func() {
-			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("10.10.0.0/15")} // 131070 hosts
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/64")}      // 2^64 hosts
+			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 512 hosts
+
+			v, err := vpn_server.BuildValues(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMax))
+		})
+
+		It("should cap MaxRoutesPerClient at RoutesPerClientMax with networks beyond /64 size", func() {
+			// special case as it does not fit into uin64
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/50")}      // 2^78 hosts
+			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 512 hosts
 
 			v, err := vpn_server.BuildValues(cfg)
 			Expect(err).ToNot(HaveOccurred())
@@ -433,20 +444,20 @@ var _ = Describe("BuildValues", func() {
 			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMin))
 		})
 
-		It("should enforce RoutesPerClientMin when no shoot networks are configured", func() {
+		It("should never fall below minimum even without any networks", func() {
 			v, err := vpn_server.BuildValues(cfg)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(v.MaxRoutesPerClient).To(Equal(constants.RoutesPerClientMin))
 		})
 
 		It("should calculate MaxRoutesPerClient from IPv6 network sizes", func() {
-			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}     // 254 hosts
+			cfg.ShootPodNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:1::/120")}     // 256 hosts
 			cfg.ShootServiceNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:2::/119")} // 512 hosts
-			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/126")}    // 2 hosts
+			cfg.ShootNodeNetworks = []network.CIDR{network.ParseIPNetIgnoreError("2001:db8:3::/126")}    // 4 hosts
 
 			v, err := vpn_server.BuildValues(cfg)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(v.MaxRoutesPerClient).To(Equal(512))
+			Expect(v.MaxRoutesPerClient).To(Equal(772))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- `max-routes-per-client` defaults to 256
- Large non-HA shoot clusters may run into this limit, resulting in the following error message, e.g.
```
2026-06-09 12:49:30 vpn-shoot-client/10.36.56.32:44524 MULTI ROUTE: route quota (256) exceeded for vpn-shoot-client/10.36.56.32:44524 (see --max-routes-per-client option)
2026-06-09 12:49:30 vpn-shoot-client/10.36.56.32:44524 MULTI: Learn FAILED: 244.1.1.119 -> vpn-shoot-client/10.36.56.32:44524
```
- This can cause disruptions as some IPs may not be reachable via VPN if their route cannot be added to the route table.
- Only affects large non-HA clusters

**Which issue(s) this PR fixes**:
- Adds `max-routes-per-client` entry to the vpn-server config based on the size of the shoot networks (within reasonable limits)
- Cleans up stale routes continuously to avoid clutter and memory leaks

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Maintain a max-routes-per-client value based on the shoot size. Clean up stale routes automatically. Only applies to non-HA VPN configurations.
```
