### PR TITLE
fix: temp disable stale route removal due to upstream OpenVPN bug

### DIFF
--- a/pkg/openvpn/assets/server-config.template
+++ b/pkg/openvpn/assets/server-config.template
@@ -23,9 +23,12 @@ port 1194
 # this value is pushed to the client, timeout is doubled on the server side, so the client is considered down after 60 seconds without traffic
 keepalive 10 30
 
-# max number of routes per client. routes go stale after 5 minutes, clean up every 10 minutes
+# max number of routes per client.
 max-routes-per-client {{ .MaxRoutesPerClient }}
-stale-routes-check 300 600
+
+## disabled until https://github.com/OpenVPN/openvpn/issues/1063 is resolved
+# routes go stale after 5 minutes, clean up every 10 minutes
+# stale-routes-check 300 600
 
 # client-config-dir to push client specific configuration
 client-config-dir /client-config-dir


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Disables the stale route removal until upstream [OpenVPN issue](https://github.com/OpenVPN/openvpn/issues/1063) is resolved.
 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Stale route check has been disabled temporarily until upstream OpenVPN issue is resolved
```
