### PR TITLE
fix: increase minimum tcp buffers to 64k

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN    cp -d /lib/ld-musl-* ./lib                                           && e
     && cp -d /usr/lib/xtables/* ./usr/lib/xtables                           && echo package iptables
 
 RUN if [ "$DEBUG" = "true" ]; then \
-       apk add --update net-tools tcpdump ndisc6 iputils-tracepath curl iproute2-tc iperf3 nmap-nping \
+       apk add --update net-tools tcpdump ndisc6 iputils-tracepath curl iproute2-tc iproute2-ss iperf3 nmap-nping \
        && cp -d /usr/lib/libpcap* ./usr/lib                                 && echo package tcpdump \
        && cp -d /usr/lib/libcurl* ./usr/lib                                 && echo package curl \
        && cp -d /usr/lib/libcares* ./usr/lib                                && echo package curl \

--- a/pkg/vpn_client/sysctl.go
+++ b/pkg/vpn_client/sysctl.go
@@ -120,6 +120,23 @@ func ConntrackSettings() error {
 	return nil
 }
 
+// BufferSettings adjusts socket buffer sizes to suit OpenVPN better.
+// Note: all buffer sizes must be within net.core.wmem_max / net.core.rmem_max as defined in
+// https://github.com/gardener/gardener/blob/master/pkg/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go#L100-L103
+func BufferSettings() error {
+	// Increase minimum send buffer to 64k (from 4k)
+	if err := sysctl.Set("net.ipv4.tcp_wmem", "65536\t12582912\t16777216"); err != nil {
+		return err
+	}
+
+	// Increase minimum receive buffer to 64k (from 4k)
+	if err := sysctl.Set("net.ipv4.tcp_rmem", "65536\t12582912\t16777216"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // KernelSettings sets the kernel parameters required for the VPN tunnel to function properly.
 func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	// Disable martian logging on both sides.
@@ -128,6 +145,10 @@ func KernelSettings(log logr.Logger, cfg config.VPNClient) error {
 	}
 	// Disable reverse path filtering on both sides.
 	if err := DisableRpFilter(); err != nil {
+		return err
+	}
+	// Adjust buffer sizes on both sides
+	if err := BufferSettings(); err != nil {
 		return err
 	}
 	// For seed clients, we need to enable IPv6 networking to be able to use IPv6 addresses for the tunnel.

--- a/pkg/vpn_client/sysctl_test.go
+++ b/pkg/vpn_client/sysctl_test.go
@@ -89,6 +89,10 @@ var _ = Describe("KernelSettings", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = sysctl.Set("net.ipv4.conf.default.rp_filter", "1")
 			Expect(err).NotTo(HaveOccurred())
+			err = sysctl.Set("net.ipv4.tcp_rmem", "4096 12582912 16777216")
+			Expect(err).NotTo(HaveOccurred())
+			err = sysctl.Set("net.ipv4.tcp_wmem", "4096 12582912 16777216")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should enable IPv6 networking", func() {
@@ -112,6 +116,19 @@ var _ = Describe("KernelSettings", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(value).To(Equal("0"))
 		})
+
+		It("should adjust buffer sizes", func() {
+			err := KernelSettings(log, cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			value, err := sysctl.Get("net.ipv4.tcp_rmem")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("65536\t12582912\t16777216"))
+
+			value, err = sysctl.Get("net.ipv4.tcp_wmem")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("65536\t12582912\t16777216"))
+		})
 	})
 
 	Context("when called for shoot client", func() {
@@ -124,6 +141,10 @@ var _ = Describe("KernelSettings", func() {
 			err = sysctl.Set("net.ipv4.conf.all.rp_filter", "1")
 			Expect(err).NotTo(HaveOccurred())
 			err = sysctl.Set("net.ipv4.conf.default.rp_filter", "1")
+			Expect(err).NotTo(HaveOccurred())
+			err = sysctl.Set("net.ipv4.tcp_rmem", "4096 12582912 16777216")
+			Expect(err).NotTo(HaveOccurred())
+			err = sysctl.Set("net.ipv4.tcp_wmem", "4096 12582912 16777216")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -230,6 +251,19 @@ var _ = Describe("KernelSettings", func() {
 			value, err = sysctl.Get("net.netfilter.nf_conntrack_tcp_timeout_max_retrans")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(value).To(Equal("120"))
+		})
+
+		It("should adjust buffer sizes", func() {
+			err := KernelSettings(log, cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			value, err := sysctl.Get("net.ipv4.tcp_rmem")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("65536\t12582912\t16777216"))
+
+			value, err = sysctl.Get("net.ipv4.tcp_wmem")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(Equal("65536\t12582912\t16777216"))
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- We've seen OpenVPN break under memory pressure
- Linux sets tcp_wmem to minimum value which is 4k by default
- Using such small buffer sizes can break encryption showing this log message on the client side:
```
2026-07-17 07:34:57 TCP/UDP packet was truncated/expanded on write to [AF_INET]52.51.154.249:8443 (tried=1540,actual=1105)
```
- Showing this message on the server side:
```
2026-07-15 20:36:31 vpn-shoot-client-1/tcp6-server:10.64.68.14:59048 Fatal decryption error (process_incoming_link), restarting
2026-07-15 20:36:31 vpn-shoot-client-1/tcp6-server:10.64.68.14:59048 SIGUSR1[soft,decryption-error] received, client-instance restarting
```

**Which issue(s) this PR fixes**:
- This fix increases the minimum buffer sizes for write and read buffers on TCP to prevent Linux from scaling it down too much under memory pressure. This will prevent OpenVPN from breaking connections.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Minimum tcp socket buffer size was increased to 64k (up from 4k) for connection stability under memory pressure.
```
