### PR TITLE
fix: bump golang to v1.26.5 in docker tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test-docker:
 	@docker run --rm --cap-add NET_ADMIN --cap-add MKNOD --privileged \
 		-v $(REPO_ROOT):/src \
 		-w /src \
-		golang:1.26.0 \
+		golang:1.26.5 \
 		go test -p 1 ./...
 
 .PHONY: build


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Update golang in docker tests to be on par with docker file

**Which issue(s) this PR fixes**:
Unblocks #314 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
NONE
```
